### PR TITLE
Forward declare wxColourDatabase before using it in a header.

### DIFF
--- a/include/wx/pdfcolour.h
+++ b/include/wx/pdfcolour.h
@@ -32,6 +32,7 @@ enum wxPdfColourType
 };
 
 /// Forward declaration of classes
+class WXDLLIMPEXP_FWD_CORE wxColourDatabase;
 class WXDLLIMPEXP_FWD_PDFDOC wxPdfPattern;
 class WXDLLIMPEXP_FWD_PDFDOC wxPdfSpotColour;
 


### PR DESCRIPTION
This makes it possible to include wx/pdfcolour.h (and, hence, wx/pdfdoc.h
which includes it) without having to include wx/gdicmn.h first.