### PR TITLE
Don't crash in wxPdfDC::GetTextExtent() if x or y are null.

### DIFF
--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -1229,13 +1229,26 @@ wxPdfDCImpl::DoGetTextExtent(const wxString& text,
     {
       *externalLeading = myExtLeading;
     }
-    *x = ScalePdfToFontMetric((double)const_cast<wxPdfDCImpl*>(this)->m_pdfDocument->GetStringWidth(text));
-    *y = myHeight;
+    if (x)
+    {
+      *x = ScalePdfToFontMetric((double)const_cast<wxPdfDCImpl*>(this)->m_pdfDocument->GetStringWidth(text));
+    }
+    if (y)
+    {
+      *y = myHeight;
+    }
     const_cast<wxPdfDCImpl*>(this)->SetFont(old);
   }
   else
   {
-    *x = *y = 0;
+    if (x)
+    {
+      *x = 0;
+    }
+    if (y)
+    {
+      *y = 0;
+    }
     if (descent)
     {
       *descent = 0;


### PR DESCRIPTION
This is allowed by wxDC API and the null pointers should be simply ignored,
i.e. the corresponding values shouldn't be returned.