### PR TITLE
Avoid deprecation warnings when building with wxWidgets 3.1.

### DIFF
--- a/samples/pdfdc/printing.cpp
+++ b/samples/pdfdc/printing.cpp
@@ -72,6 +72,10 @@
 
 #include "printing.h"
 
+#if !wxCHECK_VERSION(2, 9, 0)
+    #define wxPENSTYLE_DOT_DASH wxDOT_DASH
+#endif
+
 #ifndef __WXMSW__
 #include "mondrian.xpm"
 #endif
@@ -575,7 +579,7 @@ void MyFrame::Draw(wxDC& dc)
     dc.DrawText(wxT("Rectangle 200 by 80"), wxRound(40 * txtPosScaleX), wxRound(40 * txtPosScaleY));
     dc.SetUserScale(coordScaleX, coordScaleY);
 
-    dc.SetPen( wxPen(*wxBLACK,0,wxDOT_DASH) );
+    dc.SetPen( wxPen(*wxBLACK,0,wxPENSTYLE_DOT_DASH) );
     dc.DrawEllipse(50, 140, 100, 50);
     dc.SetPen(*wxRED_PEN);
 
@@ -1630,7 +1634,7 @@ void MyPrintout::DrawPageTwo()
         wxString words[7] = {_T("This "), _T("is "), _T("GetTextExtent "), _T("testing "), _T("string. "), _T("Enjoy "), _T("it!")};
         wxCoord w, h;
         wxCoord x = 200, y= 250;
-        wxFont fnt(15, wxSWISS, wxNORMAL, wxNORMAL);
+        wxFont fnt(15, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
 
         dc->SetFont(fnt);
 

--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -681,7 +681,7 @@ void
 wxPdfDCImpl::DoDrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2)
 {
   wxCHECK_RET(m_pdfDocument, wxT("Invalid PDF DC"));
-  if  (m_pen.GetStyle() != wxTRANSPARENT)
+  if  (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
   {
     SetupBrush();
     SetupPen();
@@ -700,10 +700,8 @@ wxPdfDCImpl::DoDrawArc(wxCoord x1, wxCoord y1,
   wxCHECK_RET(m_pdfDocument, wxT("Invalid PDF DC"));
   SetupBrush();
   SetupPen();
-  const wxBrush& curBrush = GetBrush();
-  const wxPen& curPen = GetPen();
-  bool doFill = (curBrush != wxNullBrush) && curBrush.GetStyle() != wxTRANSPARENT;
-  bool doDraw = (curPen != wxNullPen) && curPen.GetStyle() != wxTRANSPARENT;
+  bool doFill = GetBrush().IsNonTransparent();
+  bool doDraw = GetPen().IsNonTransparent();
   if (doDraw || doFill)
   {
     const double start = angleByCoords(x1, y1, xc, yc);
@@ -766,10 +764,8 @@ wxPdfDCImpl::DoDrawEllipticArc(wxCoord x, wxCoord y, wxCoord width, wxCoord heig
   {
     SetupBrush();
     SetupPen();
-    const wxBrush& curBrush = GetBrush();
-    const wxPen& curPen = GetPen();
-    bool doFill = (curBrush != wxNullBrush) && curBrush.GetStyle() != wxTRANSPARENT;
-    bool doDraw = (curPen != wxNullPen) && curPen.GetStyle() != wxTRANSPARENT;
+    bool doFill = GetBrush().IsNonTransparent();
+    bool doDraw = GetPen().IsNonTransparent();
     if (doDraw || doFill)
     {
       m_pdfDocument->SetLineWidth(ScaleLogicalToPdfXRel(1)); // pen width != 1 sometimes fools readers when closing paths
@@ -886,9 +882,9 @@ wxPdfDCImpl::DoDrawBitmap(const wxBitmap& bitmap, wxCoord x, wxCoord y, bool use
     wxPen savePen = m_pen;
     wxBrush saveBrush = m_brush;
     SetPen(*wxTRANSPARENT_PEN);
-    SetBrush(wxBrush(m_textBackgroundColour, wxSOLID));
+    SetBrush(m_textBackgroundColour);
     DoDrawRectangle(xx, yy, ww, hh);
-    SetBrush(wxBrush(m_textForegroundColour, wxSOLID));
+    SetBrush(m_textForegroundColour);
     m_pdfDocument->Image(imgName, image, xx, yy, ww, hh, wxPdfLink(-1), idMask, m_jpegFormat, m_jpegQuality);
     SetBrush(saveBrush);
     SetPen(savePen);
@@ -1387,19 +1383,17 @@ int
 wxPdfDCImpl::GetDrawingStyle()
 {
   int style = wxPDF_STYLE_NOOP;
-  const wxBrush &curBrush = GetBrush();
-  bool do_brush = (curBrush != wxNullBrush) && curBrush.GetStyle() != wxTRANSPARENT;
-  const wxPen &curPen = GetPen();
-  bool do_pen = (curPen != wxNullPen) && curPen.GetWidth() && curPen.GetStyle() != wxTRANSPARENT;
-  if (do_brush && do_pen)
+  bool doFill = GetBrush().IsNonTransparent();
+  bool doDraw = GetPen().IsNonTransparent();
+  if (doFill && doDraw)
   {
     style = wxPDF_STYLE_FILLDRAW;
   }
-  else if (do_pen)
+  else if (doDraw)
   {
     style = wxPDF_STYLE_DRAW;
   }
-  else if (do_brush)
+  else if (doFill)
   {
     style = wxPDF_STYLE_FILL;
   }

--- a/src/pdfprint.cpp
+++ b/src/pdfprint.cpp
@@ -59,6 +59,10 @@
 #include "wx/pdfprint.h"
 #include <wx/intl.h>
 
+#if !wxCHECK_VERSION(2, 9, 0)
+    #define wxPENSTYLE_USER_DASH wxUSER_DASH
+#endif
+
 // ----------------------------------------------------------------------------
 // PdfPrint data
 // ----------------------------------------------------------------------------
@@ -1525,7 +1529,7 @@ wxPdfPageSetupDialogCanvas::OnPaint(wxPaintEvent& WXUNUSED(event))
   wxBrush restorebrush = dc.GetBrush();
   wxPen restorepen = dc.GetPen();
 
-  wxBrush* lightBrush = new wxBrush(wxColour(220,220,220), wxSOLID);
+  wxBrush* lightBrush = new wxBrush(wxColour(220,220,220));
 
   dc.SetBackground(*lightBrush);
   dc.Clear();
@@ -1537,7 +1541,7 @@ wxPdfPageSetupDialogCanvas::OnPaint(wxPaintEvent& WXUNUSED(event))
   // Draw a 'shadow' paper
   //------------------------------------------
 
-  wxBrush* shadowBrush = new wxBrush(wxColour(175,175,175), wxSOLID);
+  wxBrush* shadowBrush = new wxBrush(wxColour(175,175,175));
 
   dc.SetBrush(*shadowBrush);
   dc.SetPen(*wxTRANSPARENT_PEN);
@@ -1557,7 +1561,7 @@ wxPdfPageSetupDialogCanvas::OnPaint(wxPaintEvent& WXUNUSED(event))
   // Draw margins
   //------------------------------------------
 
-  wxPen* dashpen = new wxPen(wxColour(255,0,125), 1 , wxUSER_DASH );
+  wxPen* dashpen = new wxPen(wxColour(255,0,125), 1 , wxPENSTYLE_USER_DASH);
   wxDash pDash[2] = { 3, 3 };
   dashpen->SetDashes(2, pDash);
   dc.SetPen(*dashpen);


### PR DESCRIPTION
Mostly use wx{PEN,BRUSH}STYLE_XXX constants instead of just wxXXX but also
just drop some occurrences of wxSOLID which is the default style anyhow.

Also simplify the code slightly using wx{Pen,Brush}::IsNonTransparent() helper
function.

finally, use "do{Fill,Draw}" variable names consistently everywhere, instead
of "do_{brush,pen}" in a single place.