### PR TITLE
More fixes for wxWidgets 3.0 for wxPdfDCImpl

### DIFF
--- a/include/wx/pdfdc29.h
+++ b/include/wx/pdfdc29.h
@@ -35,7 +35,7 @@ public:
   wxPdfMapModeStyle GetMapModeStyle() const;
 
 private:
-    DECLARE_DYNAMIC_CLASS(wxPdfDC)
+  wxDECLARE_DYNAMIC_CLASS(wxPdfDC);
 };
 
 /// Class representing the PDF drawing context implementation
@@ -232,7 +232,7 @@ private:
   bool m_jpegFormat;
   int  m_jpegQuality;
 
-  DECLARE_DYNAMIC_CLASS(wxPdfDCImpl);
+  wxDECLARE_DYNAMIC_CLASS(wxPdfDCImpl);
 };
 
 #endif

--- a/include/wx/pdfdc29.h
+++ b/include/wx/pdfdc29.h
@@ -172,17 +172,19 @@ protected:
   virtual void DoDrawPolygon(int n, const wxPoint points[],
                              wxCoord xoffset, wxCoord yoffset,
                              wxPolygonFillMode fillStyle = wxODDEVEN_RULE);
+  virtual void DoDrawPolyPolygon(int n, const int count[], const wxPoint points[],
+                                 wxCoord xoffset, wxCoord yoffset,
+                                 wxPolygonFillMode fillStyle);
 #else
   virtual void DoDrawLines(int n, wxPoint points[],
                            wxCoord xoffset, wxCoord yoffset);
   virtual void DoDrawPolygon(int n, wxPoint points[],
                              wxCoord xoffset, wxCoord yoffset,
                              wxPolygonFillMode fillStyle = wxODDEVEN_RULE);
-#endif // wxCHECK_VERSION
-
   virtual void DoDrawPolyPolygon(int n, int count[], wxPoint points[],
                                  wxCoord xoffset, wxCoord yoffset,
                                  int fillStyle);
+#endif // wxCHECK_VERSION
 
   virtual void DoSetClippingRegionAsRegion(const wxRegion& region);
   virtual void DoSetClippingRegion(wxCoord x, wxCoord y,

--- a/include/wx/pdfdc29.h
+++ b/include/wx/pdfdc29.h
@@ -127,7 +127,7 @@ protected:
   virtual void DoDrawPoint(wxCoord x, wxCoord y);
 
 #if wxUSE_SPLINES
-  virtual void DoDrawSpline(wxList* points);
+  virtual void DoDrawSpline(const wxPointList* points);
 #endif
 
   virtual void DoDrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2);

--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -1115,10 +1115,17 @@ wxPdfDCImpl::DoDrawPolygon(int n, wxPoint points[],
   m_pdfDocument->SetFillingRule(saveFillingRule);
 }
 
+#if wxCHECK_VERSION(2,9,5)
+void
+wxPdfDCImpl::DoDrawPolyPolygon(int n, const int count[], const wxPoint points[],
+                               wxCoord xoffset, wxCoord yoffset,
+                               wxPolygonFillMode fillStyle)
+#else // wx < 2.9.5
 void
 wxPdfDCImpl::DoDrawPolyPolygon(int n, int count[], wxPoint points[],
                                wxCoord xoffset, wxCoord yoffset,
                                int fillStyle)
+#endif // wxCHECK_VERSION
 {
   wxCHECK_RET(m_pdfDocument, wxT("Invalid PDF DC"));
   if (n > 0)
@@ -1137,7 +1144,7 @@ wxPdfDCImpl::DoDrawPolyPolygon(int n, int count[], wxPoint points[],
       wxPdfArrayDouble yp;
       for (i = 0; i < count[j]; ++i)
       {
-        wxPoint& point = points[ofs+i];
+        const wxPoint& point = points[ofs+i];
         xp.Add(ScaleLogicalToPdfX(xoffset + point.x));
         yp.Add(ScaleLogicalToPdfY(yoffset + point.y));
         CalcBoundingBox(point.x + xoffset, point.y + yoffset);

--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -583,7 +583,7 @@ wxPdfDCImpl::DoDrawPoint(wxCoord x, wxCoord y)
 
 #if wxUSE_SPLINES
 void
-wxPdfDCImpl::DoDrawSpline(wxList* points)
+wxPdfDCImpl::DoDrawSpline(const wxPointList* points)
 {
   wxCHECK_RET(m_pdfDocument, wxT("Invalid PDF DC"));
   SetPen( m_pen );
@@ -622,7 +622,7 @@ wxPdfDCImpl::DoDrawSpline(wxList* points)
   double x1, y1, x2, y2, cx1, cy1, cx4, cy4;
   double bx1, by1, bx2, by2, bx3, by3;
 
-  wxList::compatibility_iterator node = points->GetFirst();
+  wxPointList::compatibility_iterator node = points->GetFirst();
   wxPoint* p = (wxPoint*) node->GetData();
 
   x1 = ScaleLogicalToPdfX(p->x);


### PR DESCRIPTION
The changes here were done originally just because I was getting warnings each time when including `pdfdc.h` (which they fix), but they actually turn out to fix serious problems with drawing poly-polygons and splines which previously didn't work at all with wx3 as the methods that were supposed to be overridden actually were not as they didn't have the correct signature.