### PR TITLE
Fix harmless but annoying VC14 warnings

### DIFF
--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -120,7 +120,7 @@ wxPdfDCImpl::wxPdfDCImpl(wxPdfDC* owner, const wxPrintData& data)
   m_ok = true;
 }
 
-wxPdfDCImpl::wxPdfDCImpl(wxPdfDC* owner, const wxString& file, int w, int h)
+wxPdfDCImpl::wxPdfDCImpl(wxPdfDC* owner, const wxString& file, int WXUNUSED(w), int WXUNUSED(h))
   : wxDCImpl(owner)
 {
   Init();

--- a/src/pdffontdatacore.cpp
+++ b/src/pdffontdatacore.cpp
@@ -57,7 +57,6 @@ wxPdfFontDataCore::wxPdfFontDataCore(const wxString& family, const wxString& ali
   if (kpArray != NULL)
   {
     m_kp = new wxPdfKernPairMap();
-    wxPdfKernPairMap::iterator kp;
     wxPdfKernWidthMap* kwMap = NULL;
     wxPdfKernWidthMap::iterator kw;
     wxUint32 u1, u2;

--- a/src/pdffontdatatype0.cpp
+++ b/src/pdffontdatatype0.cpp
@@ -250,7 +250,6 @@ wxPdfFontDataType0::GetStringWidth(const wxString& s, const wxPdfEncoding* encod
   wxString t = ConvertToValid(s);
   // Get width of a string in the current font
   double w = 0;
-  wxPdfGlyphWidthMap::iterator charIter;
   wxString::const_iterator ch;
   for (ch = t.begin(); ch != t.end(); ++ch)
   {

--- a/src/pdffontparsertruetype.cpp
+++ b/src/pdffontparsertruetype.cpp
@@ -1642,7 +1642,6 @@ wxPdfFontParserTrueType::ReadKerning(int unitsPerEm)
     tableLocation = entry->second;
     LockTable(wxT("kern"));
     m_kp = new wxPdfKernPairMap();
-    wxPdfKernPairMap::iterator kp;
     wxPdfKernWidthMap* kwMap = NULL;
     wxPdfKernWidthMap::iterator kw;
     wxUint32 u1, u2;

--- a/src/pdffontparsertype1.cpp
+++ b/src/pdffontparsertype1.cpp
@@ -399,7 +399,6 @@ wxPdfFontParserType1::ReadAFM(wxInputStream& afmFile)
     wxString token, tokenBoxHeight;
     long nParam;
     long cc, width, boxHeight, glyphNumber;
-    wxString weight;
     bool hasGlyphNumbers = false;
 
     bool inHeader = true;
@@ -1212,11 +1211,10 @@ wxPdfFontParserType1::ReadPFM(wxInputStream& pfmFile)
   // the hyphen to a space.  This actually works in a lot of cases.
   wxString fullName = fontName;
   fullName.Replace(wxT("-"), wxT(" "));
-  wxString familyName = wxEmptyString;
   if (hdr.face != 0)
   {
     pfmFile.SeekI(hdr.face);
-    wxString familyName = ReadString(pfmFile);
+    ReadString(pfmFile);
   }
 
   wxString encodingScheme = (hdr.charset != 0) ? wxString(wxT("FontSpecific")) : wxString(wxT("AdobeStandardEncoding"));
@@ -1417,10 +1415,8 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
     bool found = false;
     wxString token = wxEmptyString;
     int limit = (int) stream->GetSize();
-    int offset;
     while(!found && stream->TellI() < limit)
     {
-      offset = stream->TellI();
       token = GetToken(stream);
       if (token.IsSameAs(wxT("eexec")))
       {
@@ -1428,7 +1424,6 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
       }
       else
       {
-        //stream->SeekI(offset);
         SkipToNextToken(stream);
       }
     }
@@ -2067,7 +2062,6 @@ wxPdfFontParserType1::ParseDict(wxInputStream* stream, int start, int length, bo
   bool ok = true;
   bool haveInteger = false;
   long intValue = 0;
-  wxString token;
   int limit = start + length;
   stream->SeekI(start);
   while (!ready && stream->TellI() < limit)
@@ -2331,8 +2325,7 @@ wxPdfFontParserType1::ParseEncoding(wxInputStream* stream)
     while (true)
     {
       // Stop when next token is 'def' or ']'
-      char ch = stream->Peek();
-      if (ch == ']')
+      if (stream->Peek() == ']')
       {
         break;
       }
@@ -2370,7 +2363,7 @@ wxPdfFontParserType1::ParseEncoding(wxInputStream* stream)
   }
   else
   {
-    wxString token = GetToken(stream);
+    token = GetToken(stream);
     if (token.IsSameAs(wxT("StandardEncoding"))   ||
         token.IsSameAs(wxT("ExpertEncoding"))     ||
         token.IsSameAs(wxT("ISOLatin1Encoding")))

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -930,8 +930,7 @@ wxPdfDocument::PutPages()
     Out("<</Type /Page");
     Out("/Parent 1 0 R");
 
-    wxPdfBoolHashMap::iterator oChange = (*m_orientationChanges).find(n);
-    if (oChange != (*m_orientationChanges).end())
+    if ((*m_orientationChanges).find(n) != (*m_orientationChanges).end())
     {
       wxSize pageSize = (*m_pageSizes)[n];
       double pageWidth = pageSize.GetWidth() / 254. * 72.;
@@ -970,12 +969,11 @@ wxPdfDocument::PutPages()
         else
         {
           wxPdfLink* link = (*m_links)[pl->GetLinkRef()];
-          wxPdfBoolHashMap::iterator oChange = (*m_orientationChanges).find(link->GetPage());
           double y = link->GetPosition()*m_k; 
           if (m_yAxisOriginTop)
           {
             double h = hPt;
-            if (oChange != (*m_orientationChanges).end())
+            if ((*m_orientationChanges).find(link->GetPage()) != (*m_orientationChanges).end())
             {
               wxSize pageSize = (*m_pageSizes)[link->GetPage()];
               h = pageSize.GetHeight() / 254. * 72.;
@@ -1743,10 +1741,9 @@ wxPdfDocument::PutTemplates()
           wxPdfImage* currentImage = image->second;
           OutAscii(wxString::Format(wxT("/I%d %d 0 R"), currentImage->GetIndex(), currentImage->GetObjIndex()));
         }
-        wxPdfTemplatesMap::iterator templateIter = currentTemplate->m_templates->begin();
-        for (templateIter = currentTemplate->m_templates->begin(); templateIter != currentTemplate->m_templates->end(); templateIter++)
+        for (wxPdfTemplatesMap::iterator templateIter2 = currentTemplate->m_templates->begin(); templateIter2 != currentTemplate->m_templates->end(); templateIter2++)
         {
-          wxPdfTemplate* tpl = templateIter->second;
+          wxPdfTemplate* tpl = templateIter2->second;
           OutAscii(m_templatePrefix + wxString::Format(wxT("%d %d 0 R"), tpl->GetIndex(), tpl->GetObjIndex()));
         }
         Out(">>");

--- a/src/pdfocg.cpp
+++ b/src/pdfocg.cpp
@@ -311,8 +311,7 @@ wxPdfDocument::PutOCProperties()
   int offCount = 0;
   Out("/Order [");
   size_t n = m_ocgs->size();
-  size_t j;
-  for (j = 1; j <= n; ++j)
+  for (size_t j = 1; j <= n; ++j)
   {
     wxPdfOcgType ocgType = (*m_ocgs)[j]->GetType();
     if (ocgType == wxPDF_OCG_TYPE_LAYER || ocgType == wxPDF_OCG_TYPE_TITLE)
@@ -333,7 +332,7 @@ wxPdfDocument::PutOCProperties()
   if (offCount > 0)
   {
     Out("/OFF [", false);
-    for (j = 1; j <= n; ++j)
+    for (size_t j = 1; j <= n; ++j)
     {
       if ((*m_ocgs)[j]->GetType() == wxPDF_OCG_TYPE_LAYER)
       {
@@ -350,8 +349,7 @@ wxPdfDocument::PutOCProperties()
   if (m_rgLayers->size() > 0)
   {
     Out("/RBGroups [", false);
-    size_t j;
-    for (j = 1; j <= m_rgLayers->size(); ++j)
+    for (size_t j = 1; j <= m_rgLayers->size(); ++j)
     {
       Out("[", false);
       wxPdfArrayLayer layers = (*m_rgLayers)[j]->GetGroup();
@@ -369,8 +367,7 @@ wxPdfDocument::PutOCProperties()
   {
     wxPdfArrayLayer layers = m_lockedLayers->GetGroup();
     Out("/Locked [", false);
-    size_t j;
-    for (j = 0; j < layers.GetCount(); ++j)
+    for (size_t j = 0; j < layers.GetCount(); ++j)
     {
       OutAscii(wxString::Format(wxT("%d 0 R "), layers[j]->GetObjIndex()), false);
     }


### PR DESCRIPTION
The first patch is trivial, the second one a bit less so and, annoyingly, I don't really know how to test the changes. But hopefully they don't break anything, even if one of them completely removes the `familyName` variable which didn't seem to be used at all, so even though my patches shouldn't change the code behaviour, perhaps the code was wrong to begin with...