### PR TITLE
pdfxml: Check if image fits on page

### DIFF
--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -1621,6 +1621,15 @@ wxPdfDocument::WriteXmlCell(wxXmlNode* node, wxPdfCellContext& context)
         {
           Ln();
         }
+        //Check if there is enough space left on page, if not add page
+        double breakMargin = GetBreakMargin();
+        double pageHeight = GetPageHeight();
+        double yMax = pageHeight - breakMargin;
+        if (y + h > yMax)
+        {
+          AddPage();
+          y = GetY();
+        }
         Image(src, x+delta, y, w, h);
         SetXY(x, y+h);
       }


### PR DESCRIPTION
When creating a pdf from a xml string no decision is made if the image fits on the page. I added some lines for checking if the image fits on the page and adding a new page  containing the image if not. 