### PR TITLE
Add minimal Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# This is the control file for Travis continuous integration system.
+#
+# It is used automatically for the repositories on Github if it's found in the
+# root directory of the project.
+language: cpp
+dist: trusty
+sudo: required
+compiler: gcc
+
+branches:
+    only:
+        - master
+
+before_install:
+    - sudo apt-get -qq update
+    - sudo apt-get install -y libwxgtk3.0-dev
+    - autoreconf
+
+script:
+    - set -e && echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
+    - ./configure
+    - echo -en 'travis_fold:end:script.configure\\r'
+    - echo 'Building...' && echo -en 'travis_fold:start:script.build\\r'
+    - make
+    - echo -en 'travis_fold:end:script.build\\r'
+    - echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
+    - sudo make install
+    - echo -en 'travis_fold:end:script.install\\r'


### PR DESCRIPTION
Build the library only under Ubuntu Trusty using gcc for now.

---

I'd like to enable continuous integration for this project, to at least ensure that no stupid last minute changes break the build for now (in the future I'd like to add some real tests which would be executed as part of the build), especially if the changes are committed from MSW and so might not have been tested under Unix (of course, CI is not a replacement for testing, but better to have both...). If you haven't used Travis before, you can see how a typical build looks like [here](https://travis-ci.org/vadz/wxpdfdoc/jobs/190087447).

For this to work, you need to enable Travis for your repository at https://travis-ci.org/ (you will need to create/associate Travis account with your Github account, IIRC).