### PR TITLE
Add a build using wxWidgets 2.8 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,16 @@
 # It is used automatically for the repositories on Github if it's found in the
 # root directory of the project.
 language: cpp
-dist: trusty
 sudo: required
-compiler: gcc
+
+matrix:
+    include:
+        - dist: trusty
+          compiler: gcc
+          env: WXGTK_PACKAGE=libwxgtk2.8-dev
+        - dist: trusty
+          compiler: gcc
+          env: WXGTK_PACKAGE=libwxgtk3.0-dev
 
 branches:
     only:
@@ -13,7 +20,7 @@ branches:
 
 before_install:
     - sudo apt-get -qq update
-    - sudo apt-get install -y libwxgtk3.0-dev
+    - sudo apt-get install -y $WXGTK_PACKAGE
     - autoreconf
 
 script:


### PR DESCRIPTION
Test building with both wxWidgets 3.0 and 2.8 under Ubuntu Trusty.

---

Let's see if it works (and by "it" I mean both Travis integration, which should kick in automatically for this PR, and building with 2.8).