### PR TITLE
Add OS X build to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,15 @@ matrix:
         - dist: trusty
           compiler: gcc
           env: WXGTK_PACKAGE=libwxgtk3.0-dev
+        - os: osx
+          compiler: clang
 
 branches:
     only:
         - master
 
 before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y $WXGTK_PACKAGE
+    - ./admin/travis/before_install.sh
     - autoreconf
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
           env: WXGTK_PACKAGE=libwxgtk3.0-dev
         - os: osx
           compiler: clang
+          env: CXXFLAGS=-Wno-potentially-evaluated-expression
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,7 @@ script:
     - echo -en 'travis_fold:end:script.build\\r'
     - echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
     - sudo make install
-    - echo -en 'travis_fold:end:script.install\\r'
+    - set +e && echo -en 'travis_fold:end:script.install\\r'
+
+# The "set +e" is a workaround for https://github.com/travis-ci/travis-ci/issues/6522
+

--- a/admin/travis/before_install.sh
+++ b/admin/travis/before_install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# This script is used in .travis.yml to install the dependencies before building.
+# Notice that WXGTK_PACKAGE is supposed to be defined before running it.
+
+set -e
+
+case "$TRAVIS_OS_NAME" in
+    linux)
+        sudo apt-get -qq update
+        sudo apt-get install -y $WXGTK_PACKAGE
+    ;;
+
+    osx)
+        brew update
+        brew install wxmac
+    ;;
+
+    *)
+        echo "Add commands to install wxWidgets on this platform!"
+        exit 1
+    ;;
+esac

--- a/admin/travis/before_install.sh
+++ b/admin/travis/before_install.sh
@@ -21,6 +21,3 @@ case "$TRAVIS_OS_NAME" in
         exit 1
     ;;
 esac
-
-# Workaround for https://github.com/travis-ci/travis-ci/issues/6522
-set +e

--- a/admin/travis/before_install.sh
+++ b/admin/travis/before_install.sh
@@ -21,3 +21,6 @@ case "$TRAVIS_OS_NAME" in
         exit 1
     ;;
 esac
+
+# Workaround for https://github.com/travis-ci/travis-ci/issues/6522
+set +e


### PR DESCRIPTION
Create a "before install" script to make it simpler to handle multiple
platforms in .travis.yml.