### PR TITLE
Fixes for MSW cross-compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,17 @@ endif
 AM_CXXFLAGS = -I$(top_srcdir)/include $(WX_CXXFLAGS)
 LDADD = lib@WXPDFDOC_LIBNAME@.la $(WX_LIBS)
 
+# Target-specific assignments are GNU Make-specific, but there doesn't seem to
+# be any other way to define different compilation optiosn when building
+# shared and static libraries with libtool.
+if USE_SHARED
+%.lo: AM_CXXFLAGS += -DWXMAKINGDLL_PDFDOC
+%.o: AM_CXXFLAGS += -DWXUSINGDLL_PDFDOC
+else
+%.lo: AM_CXXFLAGS += -DWXMAKINGLIB_PDFDOC
+%.o: AM_CXXFLAGS += -DWXUSINGLIB_PDFDOC
+endif
+
 # Define the directory where the library headers are installed.
 includewxdir = $(includedir)/wx
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,18 @@ else
 %.o: AM_CXXFLAGS += -DWXUSINGLIB_PDFDOC
 endif
 
+if USE_MSW
+# Use old style suffix rule instead of the pattern one as automake only
+# recognizes this kind of rules.
+#
+# Also notice that we use .res_o_o extension for the object files obtained by
+# compiling resource files, instead of just the usual .o, because we'd have
+# conflicts between object file names for foo.cpp and foo.rc otherwise. Due to
+# this we have to add the .res_o files manually to LDADD later, but such is life.
+.rc.res_o:
+	$(AM_V_GEN) $(WINDRES) -I $(top_srcdir) $(WX_CPPFLAGS) -O coff $< $@
+endif
+
 # Define the directory where the library headers are installed.
 includewxdir = $(includedir)/wx
 
@@ -189,9 +201,15 @@ samples_minimal_minimal_SOURCES = \
     samples/minimal/wmf.cpp \
     samples/minimal/xmlwrite.cpp
 
+samples_minimal_minimal_LDADD = $(LDADD)
+
+if USE_MSW
+samples_minimal_minimal_SOURCES += samples/minimal/minimal.rc
+samples_minimal_minimal_LDADD += samples/minimal/minimal.res_o
+CLEANFILES = samples/minimal/minimal.res_o
+else
 # libtool complains about unknown "-no-install" option when targetting MSW, so
-# don't use it then
-if !USE_MSW
+# use it only in the "else" branch.
 samples_minimal_minimal_LDFLAGS = -no-install
 endif
 
@@ -201,7 +219,11 @@ samples_pdfdc_pdfdc_SOURCES = \
 
 samples_pdfdc_pdfdc_LDADD = $(WX_LIBS_PDFDC_SAMPLE) $(LDADD)
 
-if !USE_MSW
+if USE_MSW
+samples_pdfdc_pdfdc_SOURCES += samples/pdfdc/printing.rc
+samples_pdfdc_pdfdc_LDADD += samples/pdfdc/printing.res_o
+CLEANFILES += samples/pdfdc/printing.res_o
+else
 samples_pdfdc_pdfdc_LDFLAGS = -no-install
 endif
 
@@ -210,7 +232,23 @@ noinst_PROGRAMS += makefont/makefont showfont/showfont
 
 makefont_makefont_SOURCES = makefont/makefont.cpp
 
+makefont_makefont_LDADD = $(LDADD)
+
+if USE_MSW
+makefont_makefont_SOURCES += makefont/makefont.rc
+makefont_makefont_LDADD += makefont/makefont.res_o
+CLEANFILES += makefont/makefont.res_o
+endif
+
 showfont_showfont_SOURCES = \
     showfont/showfont.cpp \
     showfont/unicodeblocks.h \
     showfont/unicoderanges.h
+
+showfont_showfont_LDADD = $(LDADD)
+
+if USE_MSW
+showfont_showfont_SOURCES += showfont/showfont.rc
+showfont_showfont_LDADD += showfont/showfont.res_o
+CLEANFILES += showfont/showfont.res_o
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,10 @@
 
 ACLOCAL_AMFLAGS = -I admin/m4
 
+if USE_MSW
+MSW_LIBS = -lgdi32
+endif
+
 # Flags used for compiling all the targets and linking all the executables
 # (libraries use LIBADD which is set for lib@WXPDFDOC_LIBNAME@.la only).
 AM_CXXFLAGS = -I$(top_srcdir)/include $(WX_CXXFLAGS)
@@ -133,7 +137,7 @@ noinst_HEADERS = \
     src/pdfglyphnames.inc
 
 lib@WXPDFDOC_LIBNAME@_la_LDFLAGS = -no-undefined $(AM_LDFLAGS)
-lib@WXPDFDOC_LIBNAME@_la_LIBADD = $(WX_LIBS)
+lib@WXPDFDOC_LIBNAME@_la_LIBADD = $(WX_LIBS) $(MSW_LIBS)
 
 
 # Samples (don't need to be installed).
@@ -174,7 +178,11 @@ samples_minimal_minimal_SOURCES = \
     samples/minimal/wmf.cpp \
     samples/minimal/xmlwrite.cpp
 
+# libtool complains about unknown "-no-install" option when targetting MSW, so
+# don't use it then
+if !USE_MSW
 samples_minimal_minimal_LDFLAGS = -no-install
+endif
 
 samples_pdfdc_pdfdc_SOURCES = \
     samples/pdfdc/printing.cpp \
@@ -182,7 +190,9 @@ samples_pdfdc_pdfdc_SOURCES = \
 
 samples_pdfdc_pdfdc_LDADD = $(WX_LIBS_PDFDC_SAMPLE) $(LDADD)
 
+if !USE_MSW
 samples_pdfdc_pdfdc_LDFLAGS = -no-install
+endif
 
 # Utilities (currently not installed neither, but could be).
 noinst_PROGRAMS += makefont/makefont showfont/showfont

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,23 @@ AM_INIT_AUTOMAKE([1.11 foreign subdir-objects])
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
 
-LT_INIT()
+dnl Allow adding MSW-specific fragments to the makefile.
+case "${host}" in
+    *-*-cygwin* )
+        USE_MSW=1
+        ;;
+
+    *-*-mingw32* )
+        USE_MSW=1
+        ;;
+esac
+AM_CONDITIONAL(USE_MSW, [test -n "$USE_MSW"])
+
+if test -n "$USE_MSW"; then
+    AC_CHECK_TOOL([WINDRES], [windres], no)
+fi
+
+LT_INIT([win32-dll])
 AC_PROG_CXX
 AC_LANG(C++)
 

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,8 @@ if test -n "$USE_MSW"; then
 fi
 
 LT_INIT([win32-dll])
+AM_CONDITIONAL([USE_SHARED], [test "x$enable_shared" = xyes])
+
 AC_PROG_CXX
 AC_LANG(C++)
 


### PR DESCRIPTION
With these changes, running

    ~/src/wxpdfdoc/configure --host=i686-w64-mingw32 --with-wx-confi=~/build/wx/msw/wx-config

and then `make` works and produces apparently working MSW executables for the samples.