### PR TITLE
Only export selected symbols from the library under Unix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,29 @@ WX_CONFIG_CHECK([2.8.0],
 WX_LIBS=$core_WX_LIBS
 AM_CONDITIONAL([BUILD_PDFDC_SAMPLE], [test -n "$WX_LIBS_PDFDC_SAMPLE"])
 
+dnl Check if the system has support for ELF visibility (this is a waste of time
+dnl when targeting MSW, so don't do it in this case).
+if test -z "$USE_MSW"; then
+    CXXFLAGS_VISIBILITY="-fvisibility=hidden -fvisibility-inlines-hidden"
+    AC_CACHE_CHECK([for visibility support],
+        [wxpdfdoc_cv_cxx_visibility],
+        [CXXFLAGS_ORIG="$CXXFLAGS"
+        CXXFLAGS="$CXXFLAGS $CXXFLAGS_VISIBILITY"
+        AC_COMPILE_IFELSE(
+            [AC_LANG_SOURCE([class __attribute__((__visibility__("default"))) Foo {
+               Foo() {}
+             };])],
+            [wxpdfdoc_cv_cxx_visibility=yes],
+            [wxpdfdoc_cv_cxx_visibility=no]
+        )
+        CXXFLAGS=$CXXFLAGS_ORIG]
+    )
+    if test "$wxpdfdoc_cv_cxx_visibility" = yes; then
+        CXXFLAGS="$CXXFLAGS $CXXFLAGS_VISIBILITY"
+        AC_DEFINE([WXPDFDOC_HAVE_VISIBILITY])
+    fi
+fi
+
 dnl This is needed by WX_LIKE_LIBNAME
 WX_DETECT_STANDARD_OPTION_VALUES
 dnl This macro is used to preserve the same name as was used with the previous

--- a/include/wx/pdfdocdef.h
+++ b/include/wx/pdfdocdef.h
@@ -1246,9 +1246,20 @@ If neither a row nor a cell background colour is specified the background is tra
 #ifndef _PDFDOC_DEF_H_
 #define _PDFDOC_DEF_H_
 
+// Unfortunately we can't always just rely on WXEXPORT because it wasn't
+// defined correctly when using ELF visibility for symbol hiding in wx 2.8 that
+// we still support, so we have to use our own symbol. This part, as well as
+// the definition of WXPDFDOC_HAVE_VISIBILITY in configure, should be dropped
+// when wx 2.8 is not supported any longer.
+#ifdef WXPDFDOC_HAVE_VISIBILITY
+    #define WXPDFDOC_EXPORT __attribute__ ((visibility("default")))
+#else
+    #define WXPDFDOC_EXPORT WXEXPORT
+#endif
+
 #if defined(WXMAKINGDLL_PDFDOC)
-  #define WXDLLIMPEXP_PDFDOC WXEXPORT
-  #define WXDLLIMPEXP_DATA_PDFDOC(type) WXEXPORT type
+  #define WXDLLIMPEXP_PDFDOC WXPDFDOC_EXPORT
+  #define WXDLLIMPEXP_DATA_PDFDOC(type) WXPDFDOC_EXPORT type
 #elif defined(WXUSINGDLL_PDFDOC)
   #define WXDLLIMPEXP_PDFDOC WXIMPORT
   #define WXDLLIMPEXP_DATA_PDFDOC(type) WXIMPORT type


### PR DESCRIPTION
Use ELF visibility to not export everything from the library by default, but
only the symbols marked with WXDLLIMPEXP_PDFDOC. This should work, i.e. export
all the really required symbols, as it already does under MSW and it removes
more than a thousand symbols that should not be exported from the library.