### PR TITLE
Add pkg-config data file for the library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,10 @@ endif
 # Define the directory where the library headers are installed.
 includewxdir = $(includedir)/wx
 
+# Ensure our pkg-config file is installed in the correct location.
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = wxpdfdoc.pc
+
 # The main library. Notice that it uses dynamic, i.e. determined when running
 # configure, name because it depends on the version of wxWidgets used. This is
 # rather unusual, but Automake doesn't seem to mind.

--- a/configure.ac
+++ b/configure.ac
@@ -132,5 +132,5 @@ AC_CONFIG_LINKS([samples/pdfdc/smile.jpg:samples/pdfdc/smile.jpg
     samples/minimal/indic-telugu.txt:samples/minimal/indic-telugu.txt
 ])
 
-AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([Makefile wxpdfdoc.pc])
 AC_OUTPUT

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,9 @@ Type `../configure --help` for more info.
 
 The autoconf-based system also supports a `make install` target which
 builds the library and then copies the headers of the component to
-`/usr/local/include` and the lib to `/usr/local/lib`.
+`/usr/local/include` and the lib to `/usr/local/lib` by default, you can use
+`pkg-config --cflags` and `--libs` to find the requires compilation and
+linking flags in general.
 
 ## <a name="execsamples"></a>Executing the sample applications
 

--- a/wxpdfdoc.pc.in
+++ b/wxpdfdoc.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+includedir=@includedir@
+libdir=@libdir@
+
+Name: wxPdfDocument
+Description: Generation of PDF documents from wxWidgets applications
+URL: https://github.com/utelle/wxpdfdoc/
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -l@WXPDFDOC_LIBNAME@
+Libs.private: @WX_LIBS@


### PR DESCRIPTION
This will allow to use it easily from the other Unix projects with the help of
PKG_CHECK_MODULES(), instead of having to check for it in a complicated way
involving using WX_LIKE_LIBNAME().

---

With this file, it's now possible to build the printing sample using a single command like this:

    g++ printing.cpp `pkg-config --cflags --libs wxpdfdoc` `wx-config --cxxflags --libs std,richtext`