### PR TITLE
Test cross-compilation to MSW on Travis CI too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ matrix:
     include:
         - dist: trusty
           compiler: gcc
-          env: WXGTK_PACKAGE=libwxgtk2.8-dev
+          env: WX_PACKAGE=libwxgtk2.8-dev
         - dist: trusty
           compiler: gcc
-          env: WXGTK_PACKAGE=libwxgtk3.0-dev
+          env: WX_PACKAGE=libwxgtk3.0-dev
+        - dist: trusty
+          env: WX_PACKAGE=libwxmsw3.0-dev HOST=i686-w64-mingw32
         - os: osx
           compiler: clang
           env: CXXFLAGS=-Wno-potentially-evaluated-expression
@@ -27,7 +29,7 @@ before_install:
 
 script:
     - set -e && echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
-    - ./configure
+    - ./configure ${HOST+--host=$HOST CXX=$HOST-g++ CC=$HOST-gcc}
     - echo -en 'travis_fold:end:script.configure\\r'
     - echo 'Building...' && echo -en 'travis_fold:start:script.build\\r'
     - make

--- a/admin/travis/before_install.sh
+++ b/admin/travis/before_install.sh
@@ -1,14 +1,25 @@
 #!/bin/sh
 #
 # This script is used in .travis.yml to install the dependencies before building.
-# Notice that WXGTK_PACKAGE is supposed to be defined before running it.
+# Notice that WX_PACKAGE is supposed to be defined before running it.
 
 set -e
 
 case "$TRAVIS_OS_NAME" in
     linux)
         sudo apt-get -qq update
-        sudo apt-get install -y $WXGTK_PACKAGE
+        case "$HOST" in
+            i686-w64-mingw32)
+                # Set up the repository containing wxMSW packages.
+                curl http://apt.tt-solutions.com/tt-apt.gpg.key | sudo apt-key add -
+                echo 'deb http://apt.tt-solutions.com/ trusty main' | sudo tee -a /etc/apt/sources.list.d/tt-solutions.list
+                sudo apt-get update -qq
+                # And also install the compiler we're going to use.
+                sudo apt-get install --no-install-recommends g++-mingw-w64-i686
+                ;;
+        esac
+
+        sudo apt-get install -y $WX_PACKAGE
     ;;
 
     osx)


### PR DESCRIPTION
Get wxMSW packages from a custom repository and test cross-building using
them.

WXGTK_PACKAGE was renamed to WX_PACKAGE as it can now also be set to
libwxmsw3.0-dev which is not really wxGTK.