### PR TITLE
Link with Fontconfig explicitly when needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,21 @@ if test -z "$USE_MSW"; then
     fi
 fi
 
+dnl With wxGTK, we also need Fontconfig library, see src/pdffontmanager.cpp.
+case "$WX_CXXFLAGS" in
+    *-D__WXGTK__* )
+        USE_GTK=1
+        ;;
+esac
+
+if test -n "$USE_GTK"; then
+    PKG_PROG_PKG_CONFIG()
+    PKG_CHECK_MODULES(FONTCONFIG, fontconfig,
+                      [CXXFLAGS="$CXXFLAGS $FONTCONFIG_CFLAGS"
+                       LIBS="$LIBS $FONTCONFIG_LIBS"],
+                      [AC_MSG_FAILURE(Required Fontconfig library not detected.)])
+fi
+
 dnl This is needed by WX_LIKE_LIBNAME
 WX_DETECT_STANDARD_OPTION_VALUES
 dnl This macro is used to preserve the same name as was used with the previous

--- a/src/pdffontmanager.cpp
+++ b/src/pdffontmanager.cpp
@@ -44,8 +44,7 @@
 #if defined(__WXMSW__)
   #include <wx/msw/registry.h>
 //  #include "wx/msw/private.h"
-#elif defined(__WXGTK20__)
-// TODO: Would testing for __WXGTK__ be sufficient?
+#elif defined(__WXGTK__)
   #include <fontconfig/fontconfig.h>
 
   // Define some FontConfig symbols if they are missing
@@ -643,8 +642,7 @@ wxPdfFontManagerBase::RegisterFont(const wxFont& font, const wxString& aliasName
                  wxString::Format(_("wxFont '%s' already registered."), font.GetFaceName().c_str()));
     }
   }
-#elif defined(__WXGTK20__)
-// TODO: Would testing for __WXGTK__ be sufficient?
+#elif defined(__WXGTK__)
 #if 0
   // TODO: Do we need to load the fontconfig library?
   FcConfig* fc = FcInitLoadConfigAndFonts();
@@ -953,8 +951,7 @@ wxPdfFontManagerBase::RegisterSystemFonts()
   }
   fontRegKey->Close();
   delete fontRegKey;
-#elif defined(__WXGTK20__)
-// TODO: Would testing for __WXGTK__ be sufficient?
+#elif defined(__WXGTK__)
 #if 0
   // TODO: Do we need to load the fontconfig library?
   FcConfig* fc = FcInitLoadConfigAndFonts();

--- a/wxpdfdoc.pc.in
+++ b/wxpdfdoc.pc.in
@@ -9,4 +9,4 @@ URL: https://github.com/utelle/wxpdfdoc/
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -l@WXPDFDOC_LIBNAME@
-Libs.private: @WX_LIBS@
+Libs.private: @WX_LIBS@ @FONTCONFIG_LIBS@


### PR DESCRIPTION
This fixes static linking when using wxGTK3, as it doesn't depend on Fontconfig any longer, unlike wxGTK2, so we need to link with it explicitly.