### PR TITLE
Don't link the static library with wxWidgets libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -165,7 +165,9 @@ noinst_HEADERS = \
     src/pdfglyphnames.inc
 
 lib@WXPDFDOC_LIBNAME@_la_LDFLAGS = -no-undefined $(AM_LDFLAGS)
+if USE_SHARED
 lib@WXPDFDOC_LIBNAME@_la_LIBADD = $(WX_LIBS) $(MSW_LIBS)
+endif
 
 
 # Samples (don't need to be installed).

--- a/admin/travis/before_install.sh
+++ b/admin/travis/before_install.sh
@@ -12,7 +12,7 @@ case "$TRAVIS_OS_NAME" in
             i686-w64-mingw32)
                 # Set up the repository containing wxMSW packages.
                 curl http://apt.tt-solutions.com/tt-apt.gpg.key | sudo apt-key add -
-                echo 'deb http://apt.tt-solutions.com/ trusty main' | sudo tee -a /etc/apt/sources.list.d/tt-solutions.list
+                echo 'deb [arch=amd64] http://apt.tt-solutions.com/ trusty main' | sudo tee -a /etc/apt/sources.list.d/tt-solutions.list
                 sudo apt-get update -qq
                 # And also install the compiler we're going to use.
                 sudo apt-get install --no-install-recommends g++-mingw-w64-i686


### PR DESCRIPTION
It is never necessary to link static libraries with anything and it was, in
fact, actively harmful instead of just useless, at least when cross-compiling
from Linux to macOS, as doing this resulted in completely bogus linker errors
about "file was built for archive which is not the architecture being linked"
(even though it was) and the library being just ignored, resulting in tons of
undefined symbol errors later.

Simply don't link the static library with anything to fix this (it's a pity
that libtool is not smart enough to only apply LIBADD to shared libraries).