### PR TITLE
Only download 64 bit versions of wxMSW packages in Travis script

### DIFF
--- a/admin/travis/before_install.sh
+++ b/admin/travis/before_install.sh
@@ -12,7 +12,7 @@ case "$TRAVIS_OS_NAME" in
             i686-w64-mingw32)
                 # Set up the repository containing wxMSW packages.
                 curl http://apt.tt-solutions.com/tt-apt.gpg.key | sudo apt-key add -
-                echo 'deb http://apt.tt-solutions.com/ trusty main' | sudo tee -a /etc/apt/sources.list.d/tt-solutions.list
+                echo 'deb [arch=amd64] http://apt.tt-solutions.com/ trusty main' | sudo tee -a /etc/apt/sources.list.d/tt-solutions.list
                 sudo apt-get update -qq
                 # And also install the compiler we're going to use.
                 sudo apt-get install --no-install-recommends g++-mingw-w64-i686


### PR DESCRIPTION
32 bit version is not available and not needed, but the updated Ubuntu VM used
by Travis seems to require it now, so explicitly tell it not to try to get it.

This should hopefully make MSW build on Travis CI work again.