### PR TITLE
Added a new map mode style: wxPDF_MAPMODESTYLE_PDFFONTS.

### DIFF
--- a/include/wx/pdfdc.h
+++ b/include/wx/pdfdc.h
@@ -27,7 +27,10 @@ enum wxPdfMapModeStyle
   wxPDF_MAPMODESTYLE_MSW,
   wxPDF_MAPMODESTYLE_GTK,
   wxPDF_MAPMODESTYLE_MAC,
-  wxPDF_MAPMODESTYLE_PDF
+  /// same font sizes and text position as with the wxPdfDocument API
+  wxPDF_MAPMODESTYLE_PDF,
+  /// same font sizes as with the wxPdfDocument API
+  wxPDF_MAPMODESTYLE_PDFFONTSCALE
 };
 
 #if wxCHECK_VERSION(2,9,0)

--- a/src/pdfdc28.inc
+++ b/src/pdfdc28.inc
@@ -1355,6 +1355,7 @@ wxPdfDC::ScaleFontSizeToPdf(int pointSize) const
       rval = (double) pointSize * fontScale * m_userScaleY;
       break;
     case wxPDF_MAPMODESTYLE_PDF:
+    case wxPDF_MAPMODESTYLE_PDFFONTSCALE:
       // an implementation where a font size of 12 gets a 12 point font if the
       // mapping mode is wxMM_POINTS and suitable scaled for other modes
       fontScale = (m_mappingMode == wxMM_TEXT) ? (m_ppiPdfFont / m_ppi) : (72.0 / m_ppi);
@@ -1389,7 +1390,8 @@ wxPdfDC::CalculateFontMetrics(wxPdfFontDescription* desc, int pointSize,
   int hheaAscender, hheaDescender, hheaLineGap;
 
   double size;
-  if ((m_mappingModeStyle == wxPDF_MAPMODESTYLE_PDF) && (m_mappingMode != wxMM_TEXT))
+  if ((m_mappingModeStyle == wxPDF_MAPMODESTYLE_PDF or m_mappingModeStyle ==
+      wxPDF_MAPMODESTYLE_PDFFONTSCALE) && (m_mappingMode != wxMM_TEXT))
   {
     size = (double) pointSize;
   }

--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -1468,6 +1468,7 @@ wxPdfDCImpl::ScaleFontSizeToPdf(int pointSize) const
       rval = (double) pointSize * fontScale * m_userScaleY;
       break;
     case wxPDF_MAPMODESTYLE_PDF:
+    case wxPDF_MAPMODESTYLE_PDFFONTSCALE:
       // an implementation where a font size of 12 gets a 12 point font if the
       // mapping mode is wxMM_POINTS and suitable scaled for other modes
       fontScale = (m_mappingMode == wxMM_TEXT) ? (m_ppiPdfFont / m_ppi) : (72.0 / m_ppi);
@@ -1502,7 +1503,8 @@ wxPdfDCImpl::CalculateFontMetrics(wxPdfFontDescription* desc, int pointSize,
   int hheaAscender, hheaDescender, hheaLineGap;
 
   double size;
-  if ((m_mappingModeStyle == wxPDF_MAPMODESTYLE_PDF) && (m_mappingMode != wxMM_TEXT))
+  if ((m_mappingModeStyle == wxPDF_MAPMODESTYLE_PDF or m_mappingModeStyle ==
+      wxPDF_MAPMODESTYLE_PDFFONTSCALE) && (m_mappingMode != wxMM_TEXT))
   {
     size = (double) pointSize;
   }


### PR DESCRIPTION
This mode preserve the size of the fonts in the wxPdfDC API as in the
wxPdfDocument API. However, it does not change the Y reference of texts
in wxPdfDC so that this continues to behave like all wxDC (this is
different with wxPDF_MAPMODESTYLE_PDF).