### PR TITLE
Fixed bug with dashes

### DIFF
--- a/src/pdfgraphics.cpp
+++ b/src/pdfgraphics.cpp
@@ -1887,6 +1887,10 @@ wxPdfDocument::SetLineStyle(const wxPdfLineStyle& linestyle)
     OutAscii(wxString(wxS("[")) + dashString + wxString(wxS("] ")) +
              wxPdfUtility::Double2String(phase*m_k,2) + wxString(wxS(" d")));
   }
+  else
+  {
+    OutAscii(wxString(wxS("[ ] 0 d")));
+  }
   SetDrawColour(linestyle.GetColour());
 }
 


### PR DESCRIPTION
When I setup a pen with wxPENSTYLE_LONG_DASH, it is not cleared by wxPENSTYLE_SOLID because postscript remembers the last dash pattern so that when going back to solid, [ ] 0 d must be given instead of
nothing.

Here is a minimal example to reproduce the bug and here is a patch that fixes it.


[wxpdfdoc-sample.cpp.gz](https://github.com/utelle/wxpdfdoc/files/1433398/wxpdfdoc-sample.cpp.gz)
