### PR TITLE
Remove tableNamesDefault (unused).

### DIFF
--- a/src/pdffontparsertruetype.cpp
+++ b/src/pdffontparsertruetype.cpp
@@ -455,12 +455,6 @@ wxPdfFontParserTrueType::ClearTableDirectory()
   }
 }
 
-static const wxChar* tableNamesDefault[] = {
-  wxS("cvt "), wxS("fpgm"), wxS("glyf"), wxS("head"),
-  wxS("hhea"), wxS("hmtx"), wxS("loca"), wxS("maxp"), wxS("prep"),
-  NULL
-};
-
 void
 wxPdfFontParserTrueType::LockTable(const wxString& tableName)
 {


### PR DESCRIPTION
This static variable is never referred to in the source file. It causes a warning from g++ and clang.
