### PR TITLE
Revert 69dcaa2e88 "Added correct handling of map mode [...]"

### DIFF
--- a/src/pdfdc28.inc
+++ b/src/pdfdc28.inc
@@ -876,10 +876,7 @@ wxPdfDC::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y,
     wxPdfFontDescription desc = m_pdfDocument->GetFontDescription();
     int height, descent;
     CalculateFontMetrics(&desc, fontToUse->GetPointSize(), &height, NULL, &descent, NULL);
-    if (m_mappingModeStyle != wxPDF_MAPMODESTYLE_PDF)
-    {
-      y += (height - abs(descent));
-    }
+    y += (height - abs(descent));
 
     m_pdfDocument->SetTextColour(m_textForegroundColour.Red(), m_textForegroundColour.Green(), m_textForegroundColour.Blue());
     m_pdfDocument->SetFontSize(ScaleFontSizeToPdf(fontToUse->GetPointSize()));

--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -922,10 +922,7 @@ wxPdfDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y, doubl
   wxPdfFontDescription desc = m_pdfDocument->GetFontDescription();
   int height, descent;
   CalculateFontMetrics(&desc, fontToUse->GetPointSize(), &height, NULL, &descent, NULL);
-  if (m_mappingModeStyle != wxPDF_MAPMODESTYLE_PDF)
-  {
-    y += (height - abs(descent));
-  }
+  y += (height - abs(descent));
 
   m_pdfDocument->SetTextColour(m_textForegroundColour.Red(), m_textForegroundColour.Green(), m_textForegroundColour.Blue());
   m_pdfDocument->SetFontSize(ScaleFontSizeToPdf(fontToUse->GetPointSize()));


### PR DESCRIPTION
This commit had, for some reason, disabled vertical coordinates
adjustment when outputting text via wxPdfDC, making it incompatible with
all the other wxDC implementations as the point passed to DrawText()
was used as the coordinate of the baseline of the text and not its top
left corner.

Whatever the original problem was, this fix is clearly wrong as it means
that a simple DrawText("Hello", 0, 0) doesn't show anything at all in
the generated PDF.

---

It took me a long time to realize why rendering using wxHTML on a `wxPdfDC` didn't work the same way as when previewing/rendering to the screen and the reason is that the text position wasn't handled correctly. The really annoying thing is that the original code clearly did it correctly, but then 69dcaa2e88cbfc004f6a422893490b11c86aae9e broke it for some reason. I think that commit should be simply reverted because it seems just wrong: mapping mode should only affect scaling, but not the position of the text. Please let me know if I'm missing anything.