### PR TITLE
Avoid deprecation warning for DoGetClippingBox() with wx 3.1.2+

### DIFF
--- a/include/wx/pdfprint.h
+++ b/include/wx/pdfprint.h
@@ -678,11 +678,18 @@ public:
     UpdateBoundingBox();
   }
 
+#if wxCHECK_VERSION(3, 1, 2)
+  virtual bool DoGetClippingRect(wxRect& rect) const
+  {
+    return m_dc.DoGetClippingRect(rect);
+  }
+#else // wx < 3.1.2
   virtual void DoGetClippingBox(wxCoord* x, wxCoord* y, wxCoord* w, wxCoord* h) const
   {
     m_dc.DoGetClippingBox(x, y, w, h);
     UpdateBoundingBox();
   }
+#endif // wx 3.1.2 or not
 
   virtual void DestroyClippingRegion()
   {


### PR DESCRIPTION
Override the new DoGetClippingRect() virtual method instead of the
DoGetClippingBox() to avoid deprecation warnings about using the latter.

Note that wxWidgets 3.1.2 is not released yet, this change avoids
warnings when using the latest wxWidgets master from Git (i.e. a version
including c5530b1abf36c652c29611c2ccb5a9d01305a3c1 commit).

---

This is just a trivial change to avoid a couple of warnings with the latest wxWidgets master.

Note that we don't need to call `UpdateBoundingBox()` in the new function, as this accessor doesn't change anything anyhow. In fact, the old one (`DoGetClippingBox()`) doesn't need it neither, but I decided not to remove it in the same PR.