### PR TITLE
Changed wxPdfArrayUint16, wxPdfArrayUint32 and wxPdfSortedArrayInt to…

### DIFF
--- a/include/wx/pdfarraytypes.h
+++ b/include/wx/pdfarraytypes.h
@@ -18,10 +18,23 @@
 // wxPdfDocument headers
 #include "wx/pdfdocdef.h"
 
+#if wxCHECK_VERSION(3,1,2)
+
 /// Unsorted array types
 WX_DEFINE_ARRAY_SHORT(wxUint16, wxPdfArrayUint16);
 WX_DEFINE_ARRAY_LONG(wxUint32, wxPdfArrayUint32);
 
 /// Sorted array types
 WX_DEFINE_SORTED_ARRAY_INT(int, wxPdfSortedArrayInt);
-#endif
+
+#else // wx < 3.1.2
+
+/// Unsorted array types
+WX_DEFINE_USER_EXPORTED_ARRAY_SHORT(wxUint16, wxPdfArrayUint16, class WXDLLIMPEXP_PDFDOC);
+WX_DEFINE_USER_EXPORTED_ARRAY_LONG(wxUint32, wxPdfArrayUint32, class WXDLLIMPEXP_PDFDOC);
+
+/// Sorted array types
+WX_DEFINE_SORTED_USER_EXPORTED_ARRAY_INT(int, wxPdfSortedArrayInt, WXDLLIMPEXP_PDFDOC);
+
+#endif // wxCHECK_VERSION
+#endif // _PDF_ARRAY_TYPES_H_

--- a/include/wx/pdfarraytypes.h
+++ b/include/wx/pdfarraytypes.h
@@ -19,10 +19,9 @@
 #include "wx/pdfdocdef.h"
 
 /// Unsorted array types
-WX_DEFINE_USER_EXPORTED_ARRAY_SHORT(wxUint16, wxPdfArrayUint16, class WXDLLIMPEXP_PDFDOC);
-WX_DEFINE_USER_EXPORTED_ARRAY_LONG(wxUint32, wxPdfArrayUint32, class WXDLLIMPEXP_PDFDOC);
+WX_DEFINE_ARRAY_SHORT(wxUint16, wxPdfArrayUint16);
+WX_DEFINE_ARRAY_LONG(wxUint32, wxPdfArrayUint32);
 
 /// Sorted array types
-WX_DEFINE_SORTED_USER_EXPORTED_ARRAY_INT(int, wxPdfSortedArrayInt, WXDLLIMPEXP_PDFDOC);
-
+WX_DEFINE_SORTED_ARRAY_INT(int, wxPdfSortedArrayInt);
 #endif


### PR DESCRIPTION
… non-exported types

Exporting these types without need can lead to multiple definition linker issues (LNK2005) due to templated creation of Arraytypes in wxWidgets.