### PR TITLE
Speed up text drawing

### DIFF
--- a/include/wx/pdfdc29.h
+++ b/include/wx/pdfdc29.h
@@ -231,6 +231,9 @@ private:
   wxPrintData    m_printData;
   wxPdfMapModeStyle m_mappingModeStyle;
 
+  wxPdfColour   m_cachedPdfColour;
+  wxUint32      m_cachedRGB;
+
   bool m_jpegFormat;
   int  m_jpegQuality;
 

--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -2783,6 +2783,10 @@ protected:
   void LoadZapfDingBats();
 
 private:
+  /// Return a string key by a font name and a font encoding
+  wxString MakeFontKey(const wxString& fontName, const wxString& fontEncoding);
+
+private:
   bool                 m_yAxisOriginTop;      ///< flag whether the origin of the y axis resides at the top (or bottom) of the page
   int                  m_page;                ///< current page number
   int                  m_n;                   ///< current object number

--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -167,6 +167,8 @@ wxPdfDCImpl::Init()
   m_ppiPdfFont = screendc.GetPPI().GetHeight();
   m_mappingModeStyle = wxPDF_MAPMODESTYLE_STANDARD;
 
+  m_cachedRGB = 0;
+
   m_jpegFormat = false;
   m_jpegQuality = 75;
 
@@ -921,7 +923,17 @@ wxPdfDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y, doubl
   CalculateFontMetrics(&desc, fontToUse->GetPointSize(), &height, NULL, &descent, NULL);
   y += (height - abs(descent));
 
-  m_pdfDocument->SetTextColour(m_textForegroundColour.Red(), m_textForegroundColour.Green(), m_textForegroundColour.Blue());
+  if (m_cachedPdfColour.GetColourType() == wxPDF_COLOURTYPE_UNKNOWN ||
+      m_textForegroundColour.GetRGB() != m_cachedRGB)
+  {
+    m_cachedRGB = m_textForegroundColour.GetRGB();
+    m_cachedPdfColour.SetColour(wxColour(m_cachedRGB));
+  }
+  if (m_cachedPdfColour != m_pdfDocument->GetTextColour())
+  {
+    m_pdfDocument->SetTextColour(m_cachedPdfColour);
+  }
+
   m_pdfDocument->SetFontSize(ScaleFontSizeToPdf(fontToUse->GetPointSize()));
   m_pdfDocument->RotatedText(ScaleLogicalToPdfX(x), ScaleLogicalToPdfY(y), ScaleLogicalToPdfX(x), ScaleLogicalToPdfY(originalY), text, angle);
   SetFont(old);

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -267,11 +267,11 @@ wxPdfDocument::SelectFont(const wxPdfFont& font, int style, double size, bool se
     }
     if (wxPdfFontManager::GetFontManager()->InitializeFontData(font))
     {
-      wxString fontKey = wxString::Format(wxS("%s[%s]"), font.GetName().Lower().c_str(), font.GetEncoding().Lower().c_str());
+      wxString fontKey = MakeFontKey(font.GetName(), font.GetEncoding());
       // Test if font is already selected
       if (m_currentFont != NULL)
       {
-        wxString currentFontKey = wxString::Format(wxS("%s[%s]"), m_currentFont->GetOriginalName().Lower().c_str(), m_currentFont->GetFont().GetEncoding().Lower().c_str());
+        wxString currentFontKey = MakeFontKey(m_currentFont->GetOriginalName(), m_currentFont->GetFont().GetEncoding());
         selected = (fontKey.IsSameAs(currentFontKey) && m_fontStyle == (style & wxPDF_FONTSTYLE_BOLDITALIC) && m_fontSizePt == size && !m_inTemplate);
       }
       if (!selected)
@@ -2827,4 +2827,18 @@ wxPdfDocument::SetFillGradient(double x, double y, double w, double h, int gradi
     wxLogError(wxString(wxS("wxPdfDocument::SetFillGradient: ")) +
                wxString(_("Gradient Id out of range.")));
   }
+}
+
+wxString
+wxPdfDocument::MakeFontKey(const wxString& fontName, const wxString& fontEncoding)
+{
+  wxString fontKey;
+  fontKey.reserve(fontName.Length() + fontEncoding.length() + 2);
+
+  fontKey.Append(fontEncoding.Lower());
+  fontKey.Append(wxS('['));
+  fontKey.Append(fontEncoding.Lower());
+  fontKey.Append(wxS(']'));
+
+  return fontKey;
 }


### PR DESCRIPTION
I'm forwarding this from https://github.com/vadz/wxpdfdoc/pull/2 as I think this is generally useful. In our use case, it results in significant speed up when generating text-heavy PDFs and while the exact amount will depend on the exact contents, I think it should help in just about all cases.