### PR TITLE
Add configure options to skip building samples/utilities

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,8 +170,12 @@ lib@WXPDFDOC_LIBNAME@_la_LIBADD = $(WX_LIBS) $(MSW_LIBS)
 endif
 
 
+noinst_PROGRAMS=
+CLEANFILES=
+
+if BUILD_SAMPLES
 # Samples (don't need to be installed).
-noinst_PROGRAMS = samples/minimal/minimal
+noinst_PROGRAMS += samples/minimal/minimal
 
 if BUILD_PDFDC_SAMPLE
 noinst_PROGRAMS += samples/pdfdc/pdfdc
@@ -213,7 +217,7 @@ samples_minimal_minimal_LDADD = $(LDADD)
 if USE_MSW
 samples_minimal_minimal_SOURCES += samples/minimal/minimal.rc
 samples_minimal_minimal_LDADD += samples/minimal/minimal.res_o
-CLEANFILES = samples/minimal/minimal.res_o
+CLEANFILES += samples/minimal/minimal.res_o
 else
 # libtool complains about unknown "-no-install" option when targetting MSW, so
 # use it only in the "else" branch.
@@ -233,6 +237,10 @@ CLEANFILES += samples/pdfdc/printing.res_o
 else
 samples_pdfdc_pdfdc_LDFLAGS = -no-install
 endif
+
+endif
+
+if BUILD_UTILITIES
 
 # Utilities (currently not installed neither, but could be).
 noinst_PROGRAMS += makefont/makefont showfont/showfont
@@ -258,4 +266,6 @@ if USE_MSW
 showfont_showfont_SOURCES += showfont/showfont.rc
 showfont_showfont_LDADD += showfont/showfont.res_o
 CLEANFILES += showfont/showfont.res_o
+endif
+
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,30 @@ AM_INIT_AUTOMAKE([1.11 foreign subdir-objects])
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
 
+AC_ARG_ENABLE(samples,
+             [AC_HELP_STRING([--disable-samples],
+                             [don't build the samples])],
+             [case "x${enableval}" in
+                   x) ;;
+                xyes) BUILD_SAMPLES=1 ;;
+                 xno) ;;
+                   *) AC_MSG_ERROR(bad value ${enableval} for --enable-samples) ;;
+             esac],
+             [BUILD_SAMPLES=1])
+AM_CONDITIONAL([BUILD_SAMPLES], [test -n "$BUILD_SAMPLES"])
+
+AC_ARG_ENABLE(utilities,
+             [AC_HELP_STRING([--disable-utilities],
+                             [don't build the utilities])],
+             [case "x${enableval}" in
+                   x) ;;
+                xyes) BUILD_UTILITIES=1 ;;
+                 xno) ;;
+                   *) AC_MSG_ERROR(bad value ${enableval} for --enable-utilities) ;;
+             esac],
+             [BUILD_UTILITIES=1])
+AM_CONDITIONAL([BUILD_UTILITIES], [test -n "$BUILD_UTILITIES"])
+
 dnl Allow adding MSW-specific fragments to the makefile.
 case "${host}" in
     *-*-cygwin* )
@@ -47,6 +71,8 @@ WX_CONFIG_CHECK([2.8.0],
     [base,core,xml]
 )
 
+if test -n "$BUILD_SAMPLES"; then
+
 dnl We only need the libraries above for the main library itself, but the
 dnl pdfdc sample has additional requirements, check for them too (notice that
 dnl we can't use "--optional-libs" wx-config option to do it all in one check
@@ -59,6 +85,9 @@ WX_CONFIG_CHECK([2.8.0],
     [adv,base,core,html,richtext,xml]
 )
 WX_LIBS=$core_WX_LIBS
+
+fi
+
 AM_CONDITIONAL([BUILD_PDFDC_SAMPLE], [test -n "$WX_LIBS_PDFDC_SAMPLE"])
 
 dnl Check if the system has support for ELF visibility (this is a waste of time


### PR DESCRIPTION
Sometimes, e.g. when building the library as a dependency of another
application for a CI build, just the library files themselves need to be
built and it's a waste of time to build the non-installable programs, so
allow disabling building them by using the corresponding --disable-xxx
options.