### PR TITLE
Use the transparent background mode by default

### DIFF
--- a/src/pdfdc28.inc
+++ b/src/pdfdc28.inc
@@ -89,7 +89,6 @@ wxPdfDC::Init()
 {
   m_templateMode = false;
   m_ppi = 72;
-  m_bkgMode = wxSOLID;
 
   m_isInteractive = false; // Is GetPixel possible ?
   m_logicalOriginX = 0;
@@ -119,7 +118,7 @@ wxPdfDC::Init()
   m_pdfDocument = NULL;
   m_imageCount = 0;
 
-  SetBackgroundMode(wxSOLID);
+  SetBackgroundMode(wxTRANSPARENT);
 
   m_printData.SetOrientation(wxPORTRAIT);
   m_printData.SetPaperId(wxPAPER_A4);

--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -189,8 +189,6 @@ wxPdfDCImpl::Init()
   m_jpegFormat = false;
   m_jpegQuality = 75;
 
-  SetBackgroundMode(wxSOLID);
-
   m_printData.SetOrientation(wxPORTRAIT);
   m_printData.SetPaperId(wxPAPER_A4);
   m_printData.SetFilename(wxS("default.pdf"));


### PR DESCRIPTION
Don't set background mode to "solid" in wxPdfDCImpl constructor, this is
inconsistent with the standard wxDC classes, which use transparent
background by default.

Setting it to "solid" went unnoticed for a long time because background
mode was ignored anyhow, but became significant since support for it was
added in 4c54889a6213ab72e660e5a14823da2bf06b1d6c.