### PR TITLE
Use right constants in wxPdfDCImpl::SetBackgroundMode()

### DIFF
--- a/src/pdfdc29.inc
+++ b/src/pdfdc29.inc
@@ -369,7 +369,7 @@ void
 wxPdfDCImpl::SetBackgroundMode(int mode)
 {
   // TODO: check implementation
-  m_backgroundMode = (mode == wxTRANSPARENT) ? wxTRANSPARENT : wxSOLID;
+  m_backgroundMode = (mode == wxBRUSHSTYLE_TRANSPARENT) ? wxBRUSHSTYLE_TRANSPARENT : wxBRUSHSTYLE_SOLID;
 }
 
 void
@@ -989,7 +989,7 @@ wxPdfDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y, doubl
   const wxArrayString lines = wxSplit(text, '\n', '\0');
 
   // Draw background for all text lines
-  if (m_backgroundMode != wxTRANSPARENT && m_textBackgroundColour.Ok())
+  if (m_backgroundMode != wxBRUSHSTYLE_TRANSPARENT && m_textBackgroundColour.Ok())
   {
     if (angle != 0)
     {


### PR DESCRIPTION
Since WX 2.9 we should use wxBRUSHSTYLE_TRANSPARENT and wxBRUSHSTYLE_SOLID
instead of wxTRANSPARENT and wxSOLID for the background mode.

But in the sample printing.cpp we should still use old constants to
support WX 2.8.