### PR TITLE
Fix clang warning about inconsistent use of override

### DIFF
--- a/include/wx/pdfdc.h
+++ b/include/wx/pdfdc.h
@@ -80,7 +80,7 @@ public:
   wxPrintData& GetPrintData() { return m_printData; }
 
   void SetResolution(int ppi);
-  int GetResolution() const;
+  virtual int GetResolution() const wxOVERRIDE;
 
   void SetImageType(wxBitmapType bitmapType, int quality = 75);
 


### PR DESCRIPTION
Use it for wxPdfDCImpl::GetResolution() too, as this virtual function
exists (since a very long time) in the base wxDCImpl class too.

---

I'm not sure how did I manage to not notice this until now, but building with clang resulted in multiple instances of
```
In file included from $wxpdfdoc/samples/pdfdc/printing.cpp:45:
$wxpdfdoc/include/wx/pdfdc.h:83:7: warning: 'GetResolution' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  int GetResolution() const;
      ^
$wx/include/wx/dc.h:667:17: note: overridden virtual function is here
    virtual int GetResolution() const
                ^
```

which are fixed by this trivial change.
