### PR TITLE
refactoring of print table to not overwrite borders with background color

### DIFF
--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -2857,6 +2857,12 @@ protected:
 
   void LoadZapfDingBats();
 
+  /**
+   * \brief 
+   * \return Get the height of the header at the top of the page
+   */
+   double GetHeaderHeight() const; 
+
 private:
   /// Return a string key by a font name and a font encoding
   wxString MakeFontKey(const wxString& fontName, const wxString& fontEncoding);
@@ -2897,6 +2903,7 @@ private:
   double               m_w;                   ///< current width of page in user unit
   double               m_h;                   ///< current height of page in user unit
   double               m_imgscale;            ///< image scale factor
+  double               m_headerHeight;        ///< height of the user defined header
 
   double               m_tMargin;             ///< top margin
   double               m_bMargin;             ///< page break margin

--- a/include/wx/pdfxml.h
+++ b/include/wx/pdfxml.h
@@ -290,10 +290,6 @@ public:
   void Write();
   double WriteRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow);
 
-
-  /// Write one table row to the document
-  void WriteRow(unsigned int row, double x, double y);
-
   /// Set cell padding
   void SetPad(double pad) { m_pad = pad; }
 

--- a/include/wx/pdfxml.h
+++ b/include/wx/pdfxml.h
@@ -144,6 +144,7 @@ public:
   wxPdfTable* GetTable() { return m_table; }
 
 private:
+  
   double           m_maxWidth;        ///< maximum line width
   double           m_lineDelta;       ///< line delta measure
   wxPdfAlignment   m_hAlign;          ///< horizontal alignment
@@ -278,12 +279,17 @@ public:
 
   /// Insert a cell into the cell array
   void InsertCell(wxPdfTableCell* c);
+  double WriteOnPage(bool writeHeader, double x, double y);
+  double WriteRowsOnPage(unsigned firstRow, unsigned lastRow, double x, double y, bool writeHeader);
+  double WriteOnMultiplePages(bool writeHeader, const wxArrayInt& firstRowsOnNextPage, double x, double y);
 
   /// Get height of row
   double GetRowHeight(int row) { const double height = m_rowHeights[row]; return height; };
 
   /// Write table to document
   void Write();
+  double WriteRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow);
+
 
   /// Write one table row to the document
   void WriteRow(unsigned int row, double x, double y);
@@ -330,7 +336,42 @@ public:
   /// Set index of last body row
   void SetBodyRowLast(unsigned int row) { m_bodyRowLast = row; }
 
-private:
+private: 
+  /// write filling
+  void WriteFillingOfCell(unsigned int row, unsigned int col, double x, double y) const;
+  /// write filling
+  void WriteFillingOfRow(unsigned int row, double x, double y) const;
+  /// write filling
+  void WriteFillingOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y) const;
+
+  /// write borders
+  void WriteBordersOfCell(unsigned row, unsigned int col, double x, double y);
+  /// write borders
+  void WriteBordersOfRow(unsigned int row, double x, double y);
+  /// write borders
+  void WriteBordersOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y);
+
+  /// write content
+  void WriteContentOfCell(unsigned int row, unsigned int col, double x, double y, bool isHeaderRow);
+  /// write content
+  void WriteContentOfRow(unsigned int row, double x, double y, bool isHeaderRow);
+  /// write content
+  double WriteContentOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow);
+
+  ///Calculate Rows after a page break in a table
+  ///In case of line breaks the function returns an array containing first body rows on a next page
+  ///In case of no new pages, the array is empty
+  wxArrayInt GetFirstRowsOnNextPage() const;
+  /// Draw cell borders
+  void DrawCellBorders(double x, double y, double w, double h, wxPdfTableCell* cell) const;
+  /// Draw cell filling
+  void DrawCellFilling(double x, double y, double w, double h, wxPdfTableCell* cell) const;
+  /// Draw cell content
+  void DrawCellContent(double x, double y, bool isHeaderRow, double w, double h, wxPdfTableCell* cell);
+  /// calculate cell dimensions
+  void CalculateCellDimension(unsigned row, unsigned col, double& w, double& h,
+    wxPdfTableCell* cell) const;
+
   wxPdfDocument* m_document;     ///< document reference
   wxPdfDoubleHashMap m_minHeights;   ///< array of minimum row heights
   wxPdfDoubleHashMap m_rowHeights;   ///< array of row heights

--- a/include/wx/pdfxml.h
+++ b/include/wx/pdfxml.h
@@ -281,7 +281,9 @@ public:
   void InsertCell(wxPdfTableCell* c);
   double WriteOnPage(bool writeHeader, double x, double y);
   double WriteRowsOnPage(unsigned firstRow, unsigned lastRow, double x, double y, bool writeHeader);
-  double WriteOnMultiplePages(bool writeHeader, const wxArrayInt& firstRowsOnNextPage, double x, double y);
+  // Add a page and return last table row on page
+  unsigned int AddPage(wxArrayInt::const_iterator iter, wxArrayInt::const_iterator endIter);
+  double WriteTable(bool writeHeader, const wxArrayInt& lastRowsOnPage, double x, double y);
 
   /// Get height of row
   double GetRowHeight(int row) { const double height = m_rowHeights[row]; return height; };
@@ -357,7 +359,7 @@ private:
   ///Calculate Rows after a page break in a table
   ///In case of line breaks the function returns an array containing first body rows on a next page
   ///In case of no new pages, the array is empty
-  wxArrayInt GetFirstRowsOnNextPage() const;
+  wxArrayInt GetLastRowsOnPage() const;
   /// Draw cell borders
   void DrawCellBorders(double x, double y, double w, double h, wxPdfTableCell* cell) const;
   /// Draw cell filling

--- a/src/pdfdocument.cpp
+++ b/src/pdfdocument.cpp
@@ -731,8 +731,9 @@ wxPdfDocument::AddPage(int orientation, wxSize pageSize)
   m_colourFlag = cf;
 
   // Page header
+  double y = GetY();
   Header();
-
+  m_headerHeight = GetY() - y;
   // Restore line width
   if (m_lineWidth != lw)
   {

--- a/src/pdfdocument.cpp
+++ b/src/pdfdocument.cpp
@@ -2918,3 +2918,8 @@ wxPdfDocument::GetTextRenderMode() const
 {
   return m_textRenderMode;
 }
+
+double wxPdfDocument::GetHeaderHeight() const
+{
+  return m_headerHeight;
+}

--- a/src/pdfform.cpp
+++ b/src/pdfform.cpp
@@ -655,8 +655,3 @@ wxPdfDocument::LoadZapfDingBats()
     m_fontSize    = saveSize / m_k;
   }
 }
-
-double wxPdfDocument::GetHeaderHeight() const
-{
-  return m_headerHeight;
-}

--- a/src/pdfform.cpp
+++ b/src/pdfform.cpp
@@ -655,3 +655,8 @@ wxPdfDocument::LoadZapfDingBats()
     m_fontSize    = saveSize / m_k;
   }
 }
+
+double wxPdfDocument::GetHeaderHeight() const
+{
+  return m_headerHeight;
+}

--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -508,13 +508,15 @@ wxPdfTable::InsertCell(wxPdfTableCell* cell)
   }
 }
 
-double wxPdfTable::WriteOnPage(bool writeHeader, double x, double y)
+double
+wxPdfTable::WriteOnPage(bool writeHeader, double x, double y)
 {
   y = WriteRowsOnPage(m_bodyRowFirst, m_bodyRowLast, x, y, writeHeader);
   return y;
 }
 
-double wxPdfTable::WriteRowsOnPage(unsigned firstRow, unsigned lastRow, double x, double y, bool writeHeader)
+double
+wxPdfTable::WriteRowsOnPage(unsigned firstRow, unsigned lastRow, double x, double y, bool writeHeader)
 {
   if (writeHeader)
   {
@@ -524,7 +526,8 @@ double wxPdfTable::WriteRowsOnPage(unsigned firstRow, unsigned lastRow, double x
   return y;
 }
 
-double wxPdfTable::WriteOnMultiplePages(bool writeHeader, const wxArrayInt& firstRowsOnNextPage, double x, double y)
+double
+wxPdfTable::WriteOnMultiplePages(bool writeHeader, const wxArrayInt& firstRowsOnNextPage, double x, double y)
 {
   wxArrayInt::const_iterator endIter = firstRowsOnNextPage.end();
   unsigned int firstRow = m_bodyRowFirst;
@@ -578,7 +581,8 @@ wxPdfTable::Write()
 }
 
 
-double wxPdfTable::WriteRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow)
+double
+wxPdfTable::WriteRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow)
 {
   WriteFillingOfRows(firstRow, lastRow, x, y);
   WriteBordersOfRows(firstRow, lastRow, x, y);
@@ -586,7 +590,8 @@ double wxPdfTable::WriteRows(unsigned int firstRow, unsigned int lastRow, double
   return newY;
 }
 
-void wxPdfTable::WriteFillingOfCell(unsigned int row, unsigned int col, double x, double y) const
+void
+wxPdfTable::WriteFillingOfCell(unsigned int row, unsigned int col, double x, double y) const
 {
   wxPdfCellHashMap::const_iterator foundCell = m_table.find((row << 16) | col);
   if (foundCell != m_table.end())
@@ -598,7 +603,8 @@ void wxPdfTable::WriteFillingOfCell(unsigned int row, unsigned int col, double x
   }
 }
 
-void wxPdfTable::WriteFillingOfRow(unsigned int row, double x, double y) const
+void
+wxPdfTable::WriteFillingOfRow(unsigned int row, double x, double y) const
 {
   m_document->SetXY(x, y + m_pad);
   for (unsigned int col = 0; col < m_nCols; col++)
@@ -608,7 +614,8 @@ void wxPdfTable::WriteFillingOfRow(unsigned int row, double x, double y) const
   }
 }
 
-void wxPdfTable::WriteFillingOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y) const
+void
+wxPdfTable::WriteFillingOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y) const
 {
   for (unsigned int row = firstRow; row < lastRow; ++row)
   {
@@ -617,7 +624,8 @@ void wxPdfTable::WriteFillingOfRows(unsigned int firstRow, unsigned int lastRow,
   }
 }
 
-void wxPdfTable::WriteBordersOfCell(unsigned int row, unsigned int col, double x, double y)
+void
+wxPdfTable::WriteBordersOfCell(unsigned int row, unsigned int col, double x, double y)
 {
   wxPdfCellHashMap::const_iterator foundCell = m_table.find((row << 16) | col);
   if (foundCell != m_table.end())
@@ -629,7 +637,8 @@ void wxPdfTable::WriteBordersOfCell(unsigned int row, unsigned int col, double x
   }
 }
 
-void wxPdfTable::WriteBordersOfRow(unsigned int row, double x, double y)
+void
+wxPdfTable::WriteBordersOfRow(unsigned int row, double x, double y)
 {
   m_document->SetXY(x, y + m_pad);
   for (unsigned int col = 0; col < m_nCols; col++)
@@ -639,7 +648,8 @@ void wxPdfTable::WriteBordersOfRow(unsigned int row, double x, double y)
   }
 }
 
-void wxPdfTable::WriteBordersOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y)
+void
+wxPdfTable::WriteBordersOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y)
 {
   for (unsigned int row = firstRow; row < lastRow; ++row)
   {
@@ -648,7 +658,8 @@ void wxPdfTable::WriteBordersOfRows(unsigned int firstRow, unsigned int lastRow,
   }
 }
 
-void wxPdfTable::WriteContentOfCell(unsigned int row, unsigned int col, double x, double y, bool isHeaderRow)
+void
+wxPdfTable::WriteContentOfCell(unsigned int row, unsigned int col, double x, double y, bool isHeaderRow)
 {
   wxPdfCellHashMap::const_iterator foundCell = m_table.find((row << 16) | col);
   if (foundCell != m_table.end())
@@ -660,7 +671,8 @@ void wxPdfTable::WriteContentOfCell(unsigned int row, unsigned int col, double x
   }
 }
 
-void wxPdfTable::WriteContentOfRow(unsigned int row, double x, double y, bool isHeaderRow)
+void
+wxPdfTable::WriteContentOfRow(unsigned int row, double x, double y, bool isHeaderRow)
 {
   m_document->SetXY(x, y + m_pad);
   for (unsigned int col = 0; col < m_nCols; col++)
@@ -670,7 +682,8 @@ void wxPdfTable::WriteContentOfRow(unsigned int row, double x, double y, bool is
   }
 }
 
-double wxPdfTable::WriteContentOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow)
+double
+wxPdfTable::WriteContentOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow)
 {
   for (unsigned int row = firstRow; row < lastRow; ++row)
   {
@@ -680,7 +693,8 @@ double wxPdfTable::WriteContentOfRows(unsigned int firstRow, unsigned int lastRo
   return y;
 }
 
-wxArrayInt wxPdfTable::GetFirstRowsOnNextPage() const
+wxArrayInt
+wxPdfTable::GetFirstRowsOnNextPage() const
 {
   const double breakMargin = m_document->GetBreakMargin();
   const double pageHeight = m_document->GetPageHeight();
@@ -727,7 +741,8 @@ wxArrayInt wxPdfTable::GetFirstRowsOnNextPage() const
   return firstRows;
 }
 
-void wxPdfTable::DrawCellBorders(double x, double y, double w, double h, wxPdfTableCell* cell) const
+void
+wxPdfTable::DrawCellBorders(double x, double y, double w, double h, wxPdfTableCell* cell) const
 {
   int border = cell->GetBorder();
   if (border != wxPDF_BORDER_NONE)
@@ -764,7 +779,8 @@ void wxPdfTable::DrawCellBorders(double x, double y, double w, double h, wxPdfTa
   }
 }
 
-void wxPdfTable::DrawCellFilling(double x, double y, double w, double h, wxPdfTableCell* cell) const
+void
+wxPdfTable::DrawCellFilling(double x, double y, double w, double h, wxPdfTableCell* cell) const
 {
   if (cell->HasCellColour())
   {
@@ -775,7 +791,8 @@ void wxPdfTable::DrawCellFilling(double x, double y, double w, double h, wxPdfTa
   }
 }
 
-void wxPdfTable::DrawCellContent(double x, double y, bool isHeaderRow, double w, double h, wxPdfTableCell* cell)
+void
+wxPdfTable::DrawCellContent(double x, double y, bool isHeaderRow, double w, double h, wxPdfTableCell* cell)
 {
   m_document->SetLeftMargin(x + m_pad);
   m_document->SetLeftMargin(x + m_pad);
@@ -827,7 +844,8 @@ void wxPdfTable::DrawCellContent(double x, double y, bool isHeaderRow, double w,
   }
 }
 
-void wxPdfTable::CalculateCellDimension(unsigned row, unsigned col, double& w, double& h, wxPdfTableCell* cell) const
+void
+wxPdfTable::CalculateCellDimension(unsigned row, unsigned col, double& w, double& h, wxPdfTableCell* cell) const
 {
   unsigned int rowspan, colspan;
   w = 0;

--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -508,50 +508,338 @@ wxPdfTable::InsertCell(wxPdfTableCell* cell)
   }
 }
 
+double wxPdfTable::WriteOnPage(bool writeHeader, double x, double y)
+{
+  y = WriteRowsOnPage(m_bodyRowFirst, m_bodyRowLast, x, y, writeHeader);
+  return y;
+}
+
+double wxPdfTable::WriteRowsOnPage(unsigned firstRow, unsigned lastRow, double x, double y, bool writeHeader)
+{
+  if (writeHeader)
+  {
+    y = WriteRows(m_headRowFirst, m_headRowLast, x, y, true);
+  }
+  y = WriteRows(firstRow, lastRow, x, y, false);
+  return y;
+}
+
+double wxPdfTable::WriteOnMultiplePages(bool writeHeader, const wxArrayInt& firstRowsOnNextPage, double x, double y)
+{
+  wxArrayInt::const_iterator endIter = firstRowsOnNextPage.end();
+  unsigned int firstRow = m_bodyRowFirst;
+  unsigned int firstPageBreak = *firstRowsOnNextPage.begin();
+
+  if(firstPageBreak > firstRow)
+  {
+    y = WriteRowsOnPage(firstRow, firstPageBreak, x, y, writeHeader);
+  }
+
+  for(wxArrayInt::const_iterator iter = firstRowsOnNextPage.begin(); iter != endIter; ++iter)
+  {
+    m_document->AddPage(m_document->GetPageOrientation(), false);
+    y = m_document->GetY();
+    firstRow = *iter;
+    //Determine last table row on page
+    unsigned int lastRow = m_bodyRowLast;
+    wxArrayInt::const_iterator nextIter = iter + 1;
+    if(nextIter != endIter)
+    {
+      lastRow = (*nextIter);
+    }
+    //Write rows on page
+    y = WriteRowsOnPage(firstRow, lastRow, x, y, writeHeader);
+  }
+  return y;
+}
+
 void
 wxPdfTable::Write()
 {
-  bool writeHeader = m_headRowLast > m_headRowFirst;
-  bool newPage = false;
-  double saveLeftMargin = m_document->GetLeftMargin();
-  double x, y;
-  unsigned int row, headRow;
-  y = m_document->GetY();
-  double breakMargin = m_document->GetBreakMargin();
-  double pageHeight = m_document->GetPageHeight();
-  double yMax = pageHeight - breakMargin;
-  if (y + m_headHeight + m_maxHeights[m_bodyRowFirst] > yMax)
+  const bool writeHeader = m_headRowLast > m_headRowFirst;
+  const double x = m_document->GetLeftMargin();
+  double y = m_document->GetY();
+
+  // check if table is about more pages
+  // if yes, the first body rows are in the returning array
+  const wxArrayInt firstRowsOnNextPage = GetFirstRowsOnNextPage();
+
+  //Case we get everything on the same Page
+  if(firstRowsOnNextPage.empty())
   {
-    newPage = true;
+    y = WriteOnPage(writeHeader, x, y);
   }
-  for (row = m_bodyRowFirst; row < m_bodyRowLast; row++)
+  else
   {
-    if (!newPage && (y + m_maxHeights[row] > yMax))
+    //Case we have just one line break
+    y = WriteOnMultiplePages(writeHeader, firstRowsOnNextPage, x, y);
+  }
+  m_document->SetXY(x, y);
+}
+
+
+double wxPdfTable::WriteRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow)
+{
+  WriteFillingOfRows(firstRow, lastRow, x, y);
+  WriteBordersOfRows(firstRow, lastRow, x, y);
+  const double newY = WriteContentOfRows(firstRow, lastRow, x, y, isHeaderRow);
+  return newY;
+}
+
+void wxPdfTable::WriteFillingOfCell(unsigned int row, unsigned int col, double x, double y) const
+{
+  wxPdfCellHashMap::const_iterator foundCell = m_table.find((row << 16) | col);
+  if (foundCell != m_table.end())
+  {
+    wxPdfTableCell* cell = foundCell->second;
+    double w, h;
+    CalculateCellDimension(row, col, w, h, cell);
+    DrawCellFilling(x, y, w, h, cell);
+  }
+}
+
+void wxPdfTable::WriteFillingOfRow(unsigned int row, double x, double y) const
+{
+  m_document->SetXY(x, y + m_pad);
+  for (unsigned int col = 0; col < m_nCols; col++)
+  {
+    WriteFillingOfCell(row, col, x, y);
+    x += m_colWidths.find(col)->second;
+  }
+}
+
+void wxPdfTable::WriteFillingOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y) const
+{
+  for (unsigned int row = firstRow; row < lastRow; ++row)
+  {
+    WriteFillingOfRow(row, x, y);
+    y += m_rowHeights.find(row)->second;
+  }
+}
+
+void wxPdfTable::WriteBordersOfCell(unsigned int row, unsigned int col, double x, double y)
+{
+  wxPdfCellHashMap::const_iterator foundCell = m_table.find((row << 16) | col);
+  if (foundCell != m_table.end())
+  {
+    wxPdfTableCell* cell = foundCell->second;
+    double w, h;
+    CalculateCellDimension(row, col, w, h, cell);
+    DrawCellBorders(x, y, w, h, cell);
+  }
+}
+
+void wxPdfTable::WriteBordersOfRow(unsigned int row, double x, double y)
+{
+  m_document->SetXY(x, y + m_pad);
+  for (unsigned int col = 0; col < m_nCols; col++)
+  {
+    WriteBordersOfCell(row, col, x, y);
+    x += m_colWidths.find(col)->second;
+  }
+}
+
+void wxPdfTable::WriteBordersOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y)
+{
+  for (unsigned int row = firstRow; row < lastRow; ++row)
+  {
+    WriteBordersOfRow(row, x, y);
+    y += m_rowHeights.find(row)->second;
+  }
+}
+
+void wxPdfTable::WriteContentOfCell(unsigned int row, unsigned int col, double x, double y, bool isHeaderRow)
+{
+  wxPdfCellHashMap::const_iterator foundCell = m_table.find((row << 16) | col);
+  if (foundCell != m_table.end())
+  {
+    wxPdfTableCell* cell = foundCell->second;
+    double w, h;
+    CalculateCellDimension(row, col, w, h, cell);
+    DrawCellContent(x, y, isHeaderRow, w, h, cell);
+  }
+}
+
+void wxPdfTable::WriteContentOfRow(unsigned int row, double x, double y, bool isHeaderRow)
+{
+  m_document->SetXY(x, y + m_pad);
+  for (unsigned int col = 0; col < m_nCols; col++)
+  {
+    WriteContentOfCell(row, col, x, y, isHeaderRow);
+    x += m_colWidths.find(col)->second;
+  }
+}
+
+double wxPdfTable::WriteContentOfRows(unsigned int firstRow, unsigned int lastRow, double x, double y, bool isHeaderRow)
+{
+  for (unsigned int row = firstRow; row < lastRow; ++row)
+  {
+    WriteContentOfRow(row, x, y, isHeaderRow);
+    y += m_rowHeights.find(row)->second;
+  }
+  return y;
+}
+
+wxArrayInt wxPdfTable::GetFirstRowsOnNextPage() const
+{
+  const double breakMargin = m_document->GetBreakMargin();
+  const double pageHeight = m_document->GetPageHeight();
+  const double yMax = pageHeight - breakMargin;
+  const double firstBodyRowHeight = m_maxHeights.find(m_bodyRowFirst)->second;
+  const bool writeHeader = m_headRowLast > m_headRowFirst;
+  double headerHeight = 0;
+  //in case we have a line break and the table has a header, we need to consider the space of the header at the new page
+  if (writeHeader)
+  {
+    for (unsigned int headRow = m_headRowFirst; headRow < m_headRowLast; headRow++)
     {
-      newPage = true;
+      headerHeight += m_rowHeights.find(headRow)->second;
     }
-    if (newPage)
+  }
+  double y = m_document->GetY();
+  wxArrayInt firstRows;
+
+  //this means basically that we have a line break before drawing the table
+  y += m_headHeight + firstBodyRowHeight;
+  if (y > yMax)
+  {
+    firstRows.Add(m_bodyRowFirst);
+    //Maybe we have a header at the top of the next page
+    y = m_document->GetHeaderHeight();
+  }
+
+  for (unsigned int row = m_bodyRowFirst + 1; row < m_bodyRowLast; ++row)
+  {
+    const double rowHeight = m_rowHeights.find(row)->second;
+    if (y + rowHeight > yMax)
     {
-      newPage = false;
-      m_document->AddPage(m_document->GetPageOrientation(), false);
-      writeHeader = m_headRowLast > m_headRowFirst;
-      y = m_document->GetY();
+      firstRows.Add(row);
+      //Maybe we have a header at the top of the next page
+      y = m_document->GetHeaderHeight();
     }
     if (writeHeader)
     {
-      writeHeader = false;
-      for (headRow = m_headRowFirst; headRow < m_headRowLast; headRow++)
-      {
-        x = saveLeftMargin;
-        WriteRow(headRow, x, y);
-        y += m_rowHeights[headRow];
-      }
+      //consider the table header
+      y += headerHeight;
     }
-    x = saveLeftMargin;
-    WriteRow(row, x, y);
-    y += m_rowHeights[row];
+    y += rowHeight;
   }
-  m_document->SetXY(saveLeftMargin, y);
+  return firstRows;
+}
+
+void wxPdfTable::DrawCellBorders(double x, double y, double w, double h, wxPdfTableCell* cell) const
+{
+  int border = cell->GetBorder();
+  if (border != wxPDF_BORDER_NONE)
+  {
+    double savedLineWidth = m_document->GetLineWidth();
+    wxPdfColour savedDrawingColour = m_document->GetDrawColour();
+    if (m_borderWidth > 0)
+    {
+      m_document->SetLineWidth(m_borderWidth);
+    }
+    if (m_borderColour.GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+    {
+      m_document->SetDrawColour(m_borderColour);
+    }
+    if ((border & wxPDF_BORDER_FRAME) == wxPDF_BORDER_FRAME)
+    {
+      m_document->Rect(x, y, w, h);
+    }
+    else
+    {
+      if (border & wxPDF_BORDER_LEFT)   m_document->Line(x,   y,   x,   y+h);
+      if (border & wxPDF_BORDER_TOP)    m_document->Line(x,   y,   x+w, y);
+      if (border & wxPDF_BORDER_BOTTOM) m_document->Line(x,   y+h, x+w, y+h);
+      if (border & wxPDF_BORDER_RIGHT)  m_document->Line(x+w, y,   x+w, y+h);
+    }
+    if (m_borderColour.GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+    {
+      m_document->SetDrawColour(savedDrawingColour);
+    }
+    if (m_borderWidth > 0)
+    {
+      m_document->SetLineWidth(savedLineWidth);
+    }
+  }
+}
+
+void wxPdfTable::DrawCellFilling(double x, double y, double w, double h, wxPdfTableCell* cell) const
+{
+  if (cell->HasCellColour())
+  {
+    wxPdfColour saveFillColour = m_document->GetFillColour();
+    m_document->SetFillColour(cell->GetCellColour());
+    m_document->Rect(x, y, w, h, wxPDF_STYLE_FILL);
+    m_document->SetFillColour(saveFillColour);
+  }
+}
+
+void wxPdfTable::DrawCellContent(double x, double y, bool isHeaderRow, double w, double h, wxPdfTableCell* cell)
+{
+  m_document->SetLeftMargin(x + m_pad);
+  m_document->SetLeftMargin(x + m_pad);
+  double delta = h - cell->GetHeight();
+  bool useClipping = false;
+  if (delta < 0)
+  {
+    // cell height is greater than maximum allowed row height
+    // cell content exceeding the row height will be clipped
+    //
+    // TODO: Setting delta = 0 effectively forces top alignment for such cells
+    // Should such a cell be aligned as requested?
+    // That is, should the clipping occur at
+    // - the bottom for wxPDF_ALIGN_TOP,
+    // - the top for wxPDF_ALIGN_BOTTOM,
+    // - the top and the bottom for wxPDF_ALIGN_MIDDLE
+    delta = 0;
+    useClipping = true;
+  }
+  switch (cell->GetVAlign())
+  {
+  case wxPDF_ALIGN_BOTTOM:
+    m_document->SetXY(x + m_pad, y + m_pad + delta);
+    break;
+  case wxPDF_ALIGN_MIDDLE:
+    m_document->SetXY(x + m_pad, y + m_pad + 0.5 * delta);
+    break;
+  case wxPDF_ALIGN_TOP:
+  default:
+    m_document->SetXY(x + m_pad, y + m_pad);
+    break;
+  }
+  if (useClipping)
+  {
+    m_document->ClippingRect(x, y, w, h);
+  }
+  m_document->WriteXmlCell(cell->GetXmlNode(), *(cell->GetContext()));
+  if (useClipping)
+  {
+    m_document->UnsetClipping();
+  }
+  if (isHeaderRow)
+  {
+    // For header rows it is necessary to prepare the cells for reprocessing
+    delete cell->GetContext();
+    wxPdfCellContext* cellContext = new wxPdfCellContext(cell->GetWidth(), cell->GetHAlign());
+    cell->SetContext(cellContext);
+    m_document->PrepareXmlCell(cell->GetXmlNode(), *cellContext);
+  }
+}
+
+void wxPdfTable::CalculateCellDimension(unsigned row, unsigned col, double& w, double& h, wxPdfTableCell* cell) const
+{
+  unsigned int rowspan, colspan;
+  w = 0;
+  for (colspan = 0; colspan < cell->GetColSpan(); colspan++)
+  {
+    w += m_colWidths.find(col+colspan)->second;
+  }
+  h = 0;
+  for (rowspan = 0; rowspan < cell->GetRowSpan(); rowspan++)
+  {
+    h += m_rowHeights.find(row+rowspan)->second;
+  }
 }
 
 void
@@ -559,7 +847,6 @@ wxPdfTable::WriteRow(unsigned int row, double x, double y)
 {
   bool isHeaderRow = (row >= m_headRowFirst && row < m_headRowLast);
   unsigned int col;
-  unsigned int rowspan, colspan;
   double w, h;
   m_document->SetXY(x, y+m_pad);
   for (col = 0; col < m_nCols; col++)
@@ -568,103 +855,10 @@ wxPdfTable::WriteRow(unsigned int row, double x, double y)
     if (foundCell != m_table.end())
     {
       wxPdfTableCell* cell = foundCell->second;
-      w = 0;
-      for (colspan = 0; colspan < cell->GetColSpan(); colspan++)
-      {
-        w += m_colWidths[col+colspan];
-      }
-      h = 0;
-      for (rowspan = 0; rowspan < cell->GetRowSpan(); rowspan++)
-      {
-        h += m_rowHeights[row+rowspan];
-      }
-      if (cell->HasCellColour())
-      {
-        wxPdfColour saveFillColour = m_document->GetFillColour();
-        m_document->SetFillColour(cell->GetCellColour());
-        m_document->Rect(x, y, w, h, wxPDF_STYLE_FILL);
-        m_document->SetFillColour(saveFillColour);
-      }
-      int border = cell->GetBorder();
-      if (border != wxPDF_BORDER_NONE)
-      {
-        double savedLineWidth = m_document->GetLineWidth();
-        wxPdfColour savedDrawingColour = m_document->GetDrawColour();
-        if (m_borderWidth > 0)
-        {
-          m_document->SetLineWidth(m_borderWidth);
-        }
-        if (m_borderColour.GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
-        {
-          m_document->SetDrawColour(m_borderColour);
-        }
-        if ((border & wxPDF_BORDER_FRAME) == wxPDF_BORDER_FRAME)
-        {
-          m_document->Rect(x, y, w, h);
-        }
-        else
-        {
-          if (border & wxPDF_BORDER_LEFT)   m_document->Line(x,   y,   x,   y+h);
-          if (border & wxPDF_BORDER_TOP)    m_document->Line(x,   y,   x+w, y);
-          if (border & wxPDF_BORDER_BOTTOM) m_document->Line(x,   y+h, x+w, y+h);
-          if (border & wxPDF_BORDER_RIGHT)  m_document->Line(x+w, y,   x+w, y+h);
-        }
-        if (m_borderColour.GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
-        {
-          m_document->SetDrawColour(savedDrawingColour);
-        }
-        if (m_borderWidth > 0)
-        {
-          m_document->SetLineWidth(savedLineWidth);
-        }
-      }
-      m_document->SetLeftMargin(x+m_pad);
-      double delta = h - cell->GetHeight();
-      bool useClipping = false;
-      if (delta < 0)
-      {
-        // cell height is greater than maximum allowed row height
-        // cell content exceeding the row height will be clipped
-        //
-        // TODO: Setting delta = 0 effectively forces top alignment for such cells
-        // Should such a cell be aligned as requested?
-        // That is, should the clipping occur at
-        // - the bottom for wxPDF_ALIGN_TOP,
-        // - the top for wxPDF_ALIGN_BOTTOM,
-        // - the top and the bottom for wxPDF_ALIGN_MIDDLE
-        delta = 0;
-        useClipping = true;
-      }
-      switch (cell->GetVAlign())
-      {
-        case wxPDF_ALIGN_BOTTOM:
-          m_document->SetXY(x+m_pad, y+m_pad+delta);
-          break;
-        case wxPDF_ALIGN_MIDDLE:
-          m_document->SetXY(x+m_pad, y+m_pad+0.5*delta);
-          break;
-        case wxPDF_ALIGN_TOP:
-        default:
-          m_document->SetXY(x+m_pad, y+m_pad);
-          break;
-      }
-      if (useClipping)
-      {
-        m_document->ClippingRect(x, y, w, h);
-      }
-      m_document->WriteXmlCell(cell->GetXmlNode(), *(cell->GetContext()));
-      if (useClipping)
-      {
-        m_document->UnsetClipping();
-      }
-      if (isHeaderRow)
-      {
-        // For header rows it is necessary to prepare the cells for reprocessing
-        delete cell->GetContext();
-        wxPdfCellContext* cellContext = new wxPdfCellContext(cell->GetWidth(), cell->GetHAlign());
-        cell->SetContext(cellContext);
-        m_document->PrepareXmlCell(cell->GetXmlNode(), *cellContext);
-      }
+      CalculateCellDimension(row, col, w, h, cell);
+      DrawCellFilling(x, y, w, h, cell);
+      DrawCellBorders(x, y, w, h, cell);
+      DrawCellContent(x, y, isHeaderRow, w, h, cell);
     }
     x += m_colWidths[col];
   }

--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -861,28 +861,6 @@ wxPdfTable::CalculateCellDimension(unsigned row, unsigned col, double& w, double
 }
 
 void
-wxPdfTable::WriteRow(unsigned int row, double x, double y)
-{
-  bool isHeaderRow = (row >= m_headRowFirst && row < m_headRowLast);
-  unsigned int col;
-  double w, h;
-  m_document->SetXY(x, y+m_pad);
-  for (col = 0; col < m_nCols; col++)
-  {
-    wxPdfCellHashMap::iterator foundCell = m_table.find((row << 16) | col);
-    if (foundCell != m_table.end())
-    {
-      wxPdfTableCell* cell = foundCell->second;
-      CalculateCellDimension(row, col, w, h, cell);
-      DrawCellFilling(x, y, w, h, cell);
-      DrawCellBorders(x, y, w, h, cell);
-      DrawCellContent(x, y, isHeaderRow, w, h, cell);
-    }
-    x += m_colWidths[col];
-  }
-}
-
-void
 wxPdfTable::SetColumnWidth(int col, double width)
 {
   m_colWidths[col] = width;


### PR DESCRIPTION
This is an implementation of wxPdfTable::Write() which first finds page breaks, than draws on every page at first the background, than the border and at last the content.
So, the cell border is not overwritten by the background of a subsequent table cell.

The old WriteRow() is not used anymore but still available since it is part of the public interface of the class.

In wxPdfDocument a member has been added to save the height of the header on each page. This value is needed to calculate the page breaks.