### PR TITLE
Consider page top margin for page breaks in tables

### DIFF
--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -708,19 +708,10 @@ wxPdfTable::GetLastRowsOnPage() const
     const double yMax = pageHeight - breakMargin;
     const double firstBodyRowHeight = iterBodyFirst->second;
     const bool writeHeader = m_headRowLast > m_headRowFirst;
-    double headerHeight = 0;
 
     //m_document->GetHeaderHeight() is header height minus top margin, so we have to consider top margin as well
-    const double topTotalMargin = m_document->GetTopMargin() + m_document->GetHeaderHeight();
-
-    //in case we have a line break and the table has a header, we need to consider the space of the header at the new page
-    if (writeHeader)
-    {
-      for (unsigned int headRow = m_headRowFirst; headRow < m_headRowLast; headRow++)
-      {
-        headerHeight += m_rowHeights.find(headRow)->second;
-      }
-    }
+    const double topTotalMargin = m_document->GetTopMargin() + m_document->GetHeaderHeight() + m_headHeight;
+       
     double y = m_document->GetY();
 
     //this means basically that we have a line break before drawing the table
@@ -728,7 +719,7 @@ wxPdfTable::GetLastRowsOnPage() const
     if (y > yMax)
     {
       lastRows.Add(m_headRowLast);
-      //Maybe we have a header at the top of the next page
+
       y = topTotalMargin;
     }
 
@@ -739,13 +730,8 @@ wxPdfTable::GetLastRowsOnPage() const
       {
         //since m_bodyRowLast and m_headRowLast are alway one behind last, last row on page is always one behind too.
         lastRows.Add(row);
-        //Maybe we have a header at the top of the next page
+
         y = topTotalMargin;
-      }
-      if (writeHeader)
-      {
-        //consider the table header
-        y += headerHeight;
       }
       y += rowHeight;
     }

--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -709,6 +709,10 @@ wxPdfTable::GetLastRowsOnPage() const
     const double firstBodyRowHeight = iterBodyFirst->second;
     const bool writeHeader = m_headRowLast > m_headRowFirst;
     double headerHeight = 0;
+
+    //m_document->GetHeaderHeight() is header height minus top margin, so we have to consider top margin as well
+    const double topTotalMargin = m_document->GetTopMargin() + m_document->GetHeaderHeight();
+
     //in case we have a line break and the table has a header, we need to consider the space of the header at the new page
     if (writeHeader)
     {
@@ -725,7 +729,7 @@ wxPdfTable::GetLastRowsOnPage() const
     {
       lastRows.Add(m_headRowLast);
       //Maybe we have a header at the top of the next page
-      y = m_document->GetHeaderHeight();
+      y = topTotalMargin;
     }
 
     for (unsigned int row = m_bodyRowFirst + 1; row < m_bodyRowLast; ++row)
@@ -736,7 +740,7 @@ wxPdfTable::GetLastRowsOnPage() const
         //since m_bodyRowLast and m_headRowLast are alway one behind last, last row on page is always one behind too.
         lastRows.Add(row);
         //Maybe we have a header at the top of the next page
-        y = m_document->GetHeaderHeight();
+        y = topTotalMargin;
       }
       if (writeHeader)
       {

--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -711,7 +711,14 @@ wxPdfTable::GetLastRowsOnPage() const
 
     //m_document->GetHeaderHeight() is header height minus top margin, so we have to consider top margin as well
     const double topTotalMargin = m_document->GetTopMargin() + m_document->GetHeaderHeight() + m_headHeight;
-       
+
+    if (topTotalMargin + firstBodyRowHeight > yMax)
+    {
+      wxLogError(wxString(wxS("wxPdfDocument::wxPdfTable: ")) +
+        wxString(_("Not possible to draw at least one table line on a page.")));
+      return lastRows;
+    }
+
     double y = m_document->GetY();
 
     //this means basically that we have a line break before drawing the table


### PR DESCRIPTION
Since header height is the difference between top margin and header height, we have to consider the top margin to find page breaks inside tables as well