### PR TITLE
Fix misspellings and file encoding

### DIFF
--- a/include/wx/pdfbarcode.h
+++ b/include/wx/pdfbarcode.h
@@ -93,7 +93,7 @@ public:
   * distribution and warehouse industry.
   * \param xpos: abscissa of barcode
   * \param ypos: ordinate of barcode
-  * \param code: value of barcode (Note: if the length of the code is not even, a 0 is preprended.)
+  * \param code: value of barcode (Note: if the length of the code is not even, a 0 is prepended.)
   * \param basewidth: corresponds to the width of a wide bar (defaults to 1)
   * \param height: bar height (defaults to 10)
   */

--- a/include/wx/pdfbarcodezint.h
+++ b/include/wx/pdfbarcodezint.h
@@ -297,7 +297,7 @@ public:
   */
   void SetInputMode(int inputMode) { m_inputMode = inputMode; }
 
-  // Note text/eci and segs are mutally exclusive
+  // Note text/eci and segs are mutually exclusive
 
   /// Get the input data
   /**

--- a/include/wx/pdfdocdef.h
+++ b/include/wx/pdfdocdef.h
@@ -390,7 +390,7 @@ Most likely only wxWidgets 2.9.x will be supported since the internals of the ba
 wxGraphicsContext differ considerably between wxWidgets 2.8.x and 2.9.x.
 
 Added features:<br>
-- methods to draw Bezier splines through a list of points;
+- methods to draw Bézier splines through a list of points;
 the drawing sample has been extended to show the new functionality
 - PDF drawing context (wxPdfDC); not yet all methods are implemented
 - support for fonts with VOLT (Visual Ordering and Layout Tables) data
@@ -664,8 +664,8 @@ of a specific method the following alphabetical list shows all available methods
 \li wxPdfDocument::ClosePath - close a clipping path
 \li wxPdfDocument::ComboBox - add a combo box to a form
 \li wxPdfDocument::CoonsPatchGradient - define coons patch mesh gradient shading
-\li wxPdfDocument::Curve - draw a Bezier curve
-\li wxPdfDocument::CurveTo - append a cubic Bezier curve to a clipping path
+\li wxPdfDocument::Curve - draw a Bézier curve
+\li wxPdfDocument::CurveTo - append a cubic Bézier curve to a clipping path
 
 \li wxPdfDocument::Ellipse - draw an ellipse
 \li wxPdfDocument::EndTemplate - end template creation
@@ -898,7 +898,7 @@ For example, for Comic Sans MS Regular:
 
 Two files are created; the one we are interested in is comic.afm.
 
-\remark Starting with wxPdfDocument version 0.8.5 this step may be ommitted for
+\remark Starting with wxPdfDocument version 0.8.5 this step may be omitted for
 TrueType and OpenType fonts.
 
 \section mkfontgen2 Generation of the font definition file
@@ -1048,7 +1048,7 @@ TrueType Collections (.ttc) which contain multiple fonts. By default font with i
 <tr><td valign="top"><tt>-e&nbsp;ENCODING</tt></td><td>the font encoding of the font.
 \note This option is required only for \b Type1 fonts and is ignored for other font types.
 
-The encoding defines the association between a code (from 0 to 255) and an Unicode character.
+The encoding defines the association between a code (from 0 to 255) and a Unicode character.
 The first 128 are fixed and correspond to ASCII; the next 128 are variable. The following
 encodings are supported by \b ShowFont:
 
@@ -1249,9 +1249,9 @@ list item is indented.
 <tr bgcolor="#eeeeee"><td valign="top"><tt>type="1|a|A|i|I|z1|z2|z3|z4"</tt></td><td>Sets the type of the list item enumerator
 <p><tt><b>1</b></tt> displays a decimal number as the list item enumerator</p>
 <p><tt><b>a</b></tt> displays a lowercase alphabetic character as the list item enumerator</p>
-<p><tt><b>A</b></tt> displays a uppercase alphabetic character as the list item enumerator</p>
+<p><tt><b>A</b></tt> displays an uppercase alphabetic character as the list item enumerator</p>
 <p><tt><b>i</b></tt> displays a lowercase roman number as the list item enumerator</p>
-<p><tt><b>I</b></tt> displays a uppercase roman number as the list item enumerator</p>
+<p><tt><b>I</b></tt> displays an uppercase roman number as the list item enumerator</p>
 <p><tt><b>z1|z2|z3|z4</b></tt> displays number symbols of one of the 4 number series in the \b ZapfDingBats font. This option should only be used for lists of at most 10 items.</p>
 </td></tr>
 <tr bgcolor="#ddeeff"><td><tt>start="number"</tt></td><td><i>number</i> represents the enumerator value of the first list item</td></tr>
@@ -1294,7 +1294,7 @@ loading the referenced URL.
 <tr bgcolor="#6699dd"><td colspan="2"><b>Tag</b></td></tr>
 <tr bgcolor="#eeeeee"><td colspan="2"><b>&lt;a&gt;</b></td></tr>
 <tr bgcolor="#6699dd"><td><b>Attribute</b></td><td><b>Description</b></td></tr>
-<tr bgcolor="#eeeeee"><td><tt>href="url"</tt></td><td><i>url</i> is an unified resource locator.
+<tr bgcolor="#eeeeee"><td><tt>href="url"</tt></td><td><i>url</i> is a unified resource locator.
 If <i>url</i> starts with <b>#</b> it is interpreted as a reference to an internal link anchor;
 the characters following <b>#</b> are used as the name of the anchor.</td></tr>
 <tr bgcolor="#ddeeff"><td><tt>name="anchor"</tt></td><td><i>anchor</i> is the name of an internal link anchor.</td></tr>
@@ -1392,7 +1392,7 @@ The <b><tt>table</tt></b> tag may have the following attributes:
 <tr bgcolor="#eeeeee"><td colspan="2"><b>&lt;table&gt;</b></td></tr>
 <tr bgcolor="#6699dd"><td><b>Attribute</b></td><td><b>Description</b></td></tr>
 <tr bgcolor="#eeeeee"><td valign="top"><tt>border="number"</tt></td><td>Table cells may have borders on each side.
-This attribute specifies whether cells will have borders on every side or not. This may be overriden for each individual cell.
+This attribute specifies whether cells will have borders on every side or not. This may be overridden for each individual cell.
 The attribute value consists of the combination of up to 4 letters:
 <p>\b 0 - no borders<br>
 <b> &gt; 0</b> - borders on all sides of each cell<br>

--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -941,9 +941,9 @@ public:
   virtual void RoundedRect(double x, double y, double w, double h,
                            double r, int roundCorner = wxPDF_CORNER_ALL, int style = wxPDF_STYLE_DRAW);
 
-  /// Draws a Bezier curve
+  /// Draws a Bézier curve
   /**
-  * A Bezier curve is tangent to the line between the control points at either end of the curve.
+  * A Bézier curve is tangent to the line between the control points at either end of the curve.
   * \param x0: Abscissa of start point
   * \param y0: Ordinate of start point
   * \param x1: Abscissa of control point 1
@@ -968,7 +968,7 @@ public:
   * \param astart: Start angle
   * \param afinish: Finish angle
   * \param style: Style of rectangle (draw and/or fill)
-  * \param nSeg: Ellipse is made up of nSeg Bezier curves
+  * \param nSeg: Ellipse is made up of nSeg Bézier curves
   * \param doSector: connect end points of elliptic arc with center point
   */
   virtual void Ellipse(double x0, double y0, double rx, double ry = 0,
@@ -983,7 +983,7 @@ public:
   * \param astart: Start angle
   * \param afinish: Finish angle
   * \param style: Style of rectangle (draw and/or fill)
-  * \param nSeg: Circle is made up of nSeg Bezier curves
+  * \param nSeg: Circle is made up of nSeg Bézier curves
   */
   virtual void Circle(double x0, double y0, double r,
                       double astart = 0, double afinish = 360,
@@ -1051,7 +1051,7 @@ public:
                            const wxPdfLineStyle& circleLineStyle = wxPdfLineStyle(),
                            const wxPdfColour& circleFillColour = wxPdfColour());
 
-  /// Draws a Bezier spline through a list of points
+  /// Draws a Bézier spline through a list of points
   /**
   * \param x Array with abscissa values
   * \param y Array with ordinate values
@@ -1059,7 +1059,7 @@ public:
   */
   virtual void BezierSpline(const wxPdfArrayDouble& x, const wxPdfArrayDouble& y, int style);
 
-  /// Draws a closed Bezier spline through a list of points
+  /// Draws a closed Bézier spline through a list of points
   /**
   * \param x Array with abscissa values
   * \param y Array with ordinate values
@@ -1367,7 +1367,7 @@ public:
 
   /// Prints a character string.
   /**
-  * The origin is on the left of the first charcter, on the baseline.
+  * The origin is on the left of the first character, on the baseline.
   * This method allows to place a string precisely on the page, but it is usually easier to use Cell(),
   * MultiCell() or Write() which are the standard methods to print text.
   * \param x Abscissa of the origin
@@ -1618,7 +1618,7 @@ public:
 
   /**
   * Puts an image in the page
-  * The image is given by an wxImage-Object
+  * The image is given by a wxImage-Object
   * \param name Name of the image to be used as an identifier for this image object.
   * \param image wxImage object which will be embedded as PNG
   * \param x Abscissa of the upper-left corner.
@@ -1637,7 +1637,7 @@ public:
 
   /**
   * Puts an image in the page
-  * The image is given by an wxInputStream-Object containing the raw image data.
+  * The image is given by a wxInputStream-Object containing the raw image data.
   * \param name Name of the image to be used as an identifier for this image object.
   * \param stream wxInputStream object containing the raw image data
   * \param mimeType Image format. Possible values are: image/jpeg, image/png, image/gif, image/wmf.
@@ -1851,11 +1851,11 @@ public:
   */
   virtual void LineTo(double x, double y);
 
-  /// Append a cubic Bezier curve to the current (sub)path
+  /// Append a cubic Bézier curve to the current (sub)path
   /**
-  * Append a cubic Bezier curve to the current path. The curve extends
+  * Append a cubic Bézier curve to the current path. The curve extends
   * from the current point to the point (x3, y3), using (x1, y1) and (x2, y2)
-  * as the B�zier control points. The new current point is (x3, y3).
+  * as the Bézier control points. The new current point is (x3, y3).
   * \param x1: Abscissa of control point 1
   * \param y1: Ordinate of control point 1
   * \param x2: Abscissa of control point 2
@@ -2144,7 +2144,7 @@ public:
   virtual int LinearGradient(const wxPdfColour& col1, const wxPdfColour& col2,
                              wxPdfLinearGradientType gradientType = wxPDF_LINEAR_GRADIENT_HORIZONTAL);
 
-  /// Defines a axial gradient shading
+  /// Defines an axial gradient shading
   /**
   * \param col1 first colour (RGB or CMYK).
   * \param col2 second colour (RGB or CMYK).
@@ -2159,7 +2159,7 @@ public:
                             double x2 = 1, double y2 = 0,
                             double intexp = 1);
 
-  /// Defines a axial gradient shading
+  /// Defines an axial gradient shading
   /**
   * \param col1 first colour (RGB or CMYK).
   * \param col2 second colour (RGB or CMYK).
@@ -2410,7 +2410,7 @@ public:
   * \return int The ID of the created template
   * \see EndTemplate(), UseTemplate()
   *
-  * Attention: Calls to BeginTemplate can not be nested!
+  * Attention: Calls to BeginTemplate cannot be nested!
   */
   virtual int BeginTemplate(double x = 0, double y = 0, double width = 0, double height = 0);
 
@@ -2633,7 +2633,7 @@ public:
   /**
   * Attaches a file to the PDF document.
   * \param fileName path to the file to attach
-  * \param attachName the name under which the file will be attached (dfeault: filename)
+  * \param attachName the name under which the file will be attached (default: filename)
   * \param description an optional description
   */
   virtual bool AttachFile(const wxString& fileName,
@@ -2748,7 +2748,7 @@ protected:
   /// End of page contents
   virtual void EndPage();
 
-  /// End dociment
+  /// End document
   virtual void EndDoc();
 
   /// Add header
@@ -2912,7 +2912,7 @@ protected:
   /// Draws a line relative from last draw point
   void OutLineRelative(double dx, double dy);
 
-  /// Draws a B�zier curve from last draw point
+  /// Draws a Bézier curve from last draw point
   void OutCurve(double x1, double y1, double x2, double y2, double x3, double y3);
 
   /// Perform transformation
@@ -3040,7 +3040,7 @@ private:
 
   wxArrayPtrVoid       m_outlines;            ///< array of bookmarks
   int                  m_outlineRoot;         ///< number of root node
-  int                  m_maxOutlineLevel;     ///< max. occuring outline level
+  int                  m_maxOutlineLevel;     ///< max. occurring outline level
 
   wxArrayPtrVoid       m_graphicStates;       ///< array of graphic states
   wxString             m_fontPath;            ///< current default path for font files

--- a/include/wx/pdffontdata.h
+++ b/include/wx/pdffontdata.h
@@ -141,7 +141,7 @@ public:
 
   /// Set font style
   /**
-  * \param style the style of the font. Vaild values are
+  * \param style the style of the font. Valid values are
   *   \li wxPDF_FONTSTYLE_REGULAR
   *   \li wxPDF_FONTSTYLE_BOLD
   *   \li wxPDF_FONTSTYLE_ITALIC
@@ -535,7 +535,7 @@ public:
   */
   virtual bool HasVoltData() const { return false; }
 
-  /// Applay VOLT data
+  /// Apply VOLT data
   /**
   * \param s text string for which VOLT data should be applied
   * \return text string modified according to the VOLT data
@@ -770,7 +770,7 @@ protected:
 
   bool                  m_cff;             ///< Flag whether the font has a CFF table
   size_t                m_cffOffset;       ///< Offset of the CFF table of a TrueType/OpenType font
-  size_t                m_cffLength;       ///< Lenght of the CFF table of a TrueType/OpenType font
+  size_t                m_cffLength;       ///< Length of the CFF table of a TrueType/OpenType font
 
   wxString              m_cmap;            ///< CMap of a CID font
   wxString              m_ordering;        ///< Ordering of a CID font

--- a/include/wx/pdffontdataopentype.h
+++ b/include/wx/pdffontdataopentype.h
@@ -152,7 +152,7 @@ public:
   */
   void SetCffOffset(size_t cffOffset) { m_cffOffset = cffOffset; }
 
-  /// Set the lenght of the CFF section
+  /// Set the length of the CFF section
   /**
   * \param cffLength the offset of the CFF section
   */

--- a/include/wx/pdffontdatatruetype.h
+++ b/include/wx/pdffontdatatruetype.h
@@ -102,7 +102,7 @@ public:
 #endif
 
 protected:
-  wxMBConv* m_conv;   ///< Assocated encoding converter
+  wxMBConv* m_conv;   ///< Associated encoding converter
 };
 
 #if wxUSE_UNICODE

--- a/include/wx/pdffontextended.h
+++ b/include/wx/pdffontextended.h
@@ -224,7 +224,7 @@ public:
 
   /// Check whether the font will be embedded
   /**
-  * \return TRUE if the font will be embedde, FALSE otherwise
+  * \return TRUE if the font will be embedded, FALSE otherwise
   */
   bool IsEmbedded() const;
 

--- a/include/wx/pdfgradient.h
+++ b/include/wx/pdfgradient.h
@@ -67,10 +67,10 @@ public:
   /**
   * \param colour1 first colour
   * \param colour2 second colour
-  * \param x1 x ccordinate of the start point
-  * \param y1 y ccordinate of the start point
-  * \param x2 x ccordinate of the end point
-  * \param y2 y ccordinate of the end point
+  * \param x1 x coordinate of the start point
+  * \param y1 y coordinate of the start point
+  * \param x2 x coordinate of the end point
+  * \param y2 y coordinate of the end point
   * \param intexp interpolation exponent
   */
   wxPdfAxialGradient(const wxPdfColour& colour1, const wxPdfColour& colour2, double x1, double y1, double x2, double y2, double intexp);
@@ -117,10 +117,10 @@ public:
   /**
   * \param colour1 first colour
   * \param colour2 second colour
-  * \param x1 x ccordinate of the start point
-  * \param y1 y ccordinate of the start point
-  * \param x2 x ccordinate of the end point
-  * \param y2 y ccordinate of the end point
+  * \param x1 x coordinate of the start point
+  * \param y1 y coordinate of the start point
+  * \param x2 x coordinate of the end point
+  * \param y2 y coordinate of the end point
   * \param midpoint coordinate of mid point
   * \param intexp interpolation exponent
   */
@@ -144,11 +144,11 @@ public:
   /**
   * \param colour1 first colour
   * \param colour2 second colour
-  * \param x1 x ccordinate of the start point
-  * \param y1 y ccordinate of the start point
+  * \param x1 x coordinate of the start point
+  * \param y1 y coordinate of the start point
   * \param r1 radius at start point
-  * \param x2 x ccordinate of the end point
-  * \param y2 y ccordinate of the end point
+  * \param x2 x coordinate of the end point
+  * \param y2 y coordinate of the end point
   * \param r2 radius at end point
   * \param intexp interpolation exponent
   */

--- a/include/wx/pdfgraphics.h
+++ b/include/wx/pdfgraphics.h
@@ -79,7 +79,7 @@ public:
   */
   int CurrentSegment(double coords[]);
 
-  /// Subdivide cubic bezier curve path
+  /// Subdivide cubic Bézier curve path
   void SubdivideCubic();
 
   /// Check whether path iterator is done

--- a/include/wx/pdflayer.h
+++ b/include/wx/pdflayer.h
@@ -269,7 +269,7 @@ protected:
   /// Set the parent of the layer
   bool SetParent(wxPdfLayer* parent);
 
-  /// Allocate the usage dictonary
+  /// Allocate the usage dictionary
   wxPdfDictionary* AllocateUsage();
 
 private:

--- a/include/wx/pdfobjects.h
+++ b/include/wx/pdfobjects.h
@@ -58,10 +58,10 @@ public:
   // Get actual object id
   int GetActualId() { return m_actualId; }
 
-  /// Flag this object as created through a indirect reference
+  /// Flag this object as created through an indirect reference
   void SetCreatedIndirect(bool indirect) { m_indirect = indirect; }
 
-  /// Check whether this object was created through a indirect reference
+  /// Check whether this object was created through an indirect reference
   bool IsCreatedIndirect() { return m_indirect; }
 
   /// Check whether this object can be in an object stream

--- a/include/wx/pdfparser.h
+++ b/include/wx/pdfparser.h
@@ -47,7 +47,7 @@ class WXDLLIMPEXP_FWD_PDFDOC wxPdfInfo;
 #define TOKEN_NULL             12
 #define TOKEN_OTHER            13
 
-/// Class representing a tokenizer for parsing PDF documenst.
+/// Class representing a tokenizer for parsing PDF documents.
 class WXDLLIMPEXP_PDFDOC wxPdfTokenizer
 {
 public:
@@ -126,7 +126,7 @@ private:
   wxString       m_stringValue; ///< Value of last token
   int            m_reference;   ///< Reference number of object
   int            m_generation;  ///< Generation number of object
-  bool           m_hexString;   ///< Flag for hexadeciaml strings
+  bool           m_hexString;   ///< Flag for hexadecimal strings
 
 };
 

--- a/include/wx/pdfpattern.h
+++ b/include/wx/pdfpattern.h
@@ -102,7 +102,7 @@ private:
   wxPdfPatternStyle m_patternStyle; ///< pattern style
   wxPdfImage* m_image; ///< image
   int      m_templateId; ///< template id
-  wxColour m_drawColour; ///< foregorund colour
+  wxColour m_drawColour; ///< foreground colour
   wxColour m_fillColour; ///< background colour
   bool     m_hasFillColour; ///< flag whether background colour is defined for the pattern
 

--- a/include/wx/pdfshape.h
+++ b/include/wx/pdfshape.h
@@ -58,11 +58,11 @@ public:
   */
   void LineTo(double x, double y);
 
-  /// Add a cubic Bezier curve to the shape
+  /// Add a cubic Bézier curve to the shape
   /**
-  * Append a cubic Bezier curve to the current path. The curve extends
+  * Append a cubic Bézier curve to the current path. The curve extends
   * from the current point to the point (x3, y3), using (x1, y1) and (x2, y2)
-  * as the Bezier control points. The new current point is (x3, y3).
+  * as the Bézier control points. The new current point is (x3, y3).
   * \param x1: Abscissa of control point 1
   * \param y1: Ordinate of control point 1
   * \param x2: Abscissa of control point 2

--- a/src/crypto/unicode_norm.cpp
+++ b/src/crypto/unicode_norm.cpp
@@ -69,7 +69,7 @@ get_canonical_class(pg_wchar code)
   const pg_unicode_decomposition *entry = get_code_entry(code);
 
   /*
-   * If no entries are found, the character used is either an Hangul
+   * If no entries are found, the character used is either a Hangul
    * character or a character with a class of 0 and no decompositions.
    */
   if (!entry)

--- a/src/pdfcffdecoder.cpp
+++ b/src/pdfcffdecoder.cpp
@@ -362,7 +362,7 @@ wxPdfCffDecoder::ReadASubr(wxInputStream* stream, int begin, int end,
   // Clear the stack for the subrs
   EmptyStack();
   m_numHints = 0;
-  // Goto begining of the subr
+  // Goto beginning of the subr
   stream->SeekI(begin);
   while (stream->TellI() < end)
   {
@@ -428,7 +428,7 @@ wxPdfCffDecoder::ReadASubr(wxInputStream* stream, int begin, int end,
     // A call to "stem"
     else if (m_key == wxS("hstem") || m_key == wxS("vstem") || m_key == wxS("hstemhm") || m_key == wxS("vstemhm"))
     {
-      // Increment the NumOfHints by the number couples of of arguments
+      // Increment the NumOfHints by the number couples of arguments
       m_numHints += numArgs / 2;
     }
           // A call to "mask"
@@ -568,7 +568,7 @@ wxPdfCffDecoder::ReadCommand(wxInputStream* stream)
       m_argCount++;
       continue;
     }
-    if (b0 >= 247 && b0 <= 250) // The byte read and the next byte constetute a short int
+    if (b0 >= 247 && b0 <= 250) // The byte read and the next byte constitute a short int
     {
       unsigned char b1 = ReadByte(stream);
       short item = (short) ((b0-247)*256 + b1 + 108);
@@ -597,7 +597,7 @@ wxPdfCffDecoder::ReadCommand(wxInputStream* stream)
     if (b0 <= 31 && b0 != 28) // An operator was found.. Set Key.
     {
       gotKey = true;
-      // 12 is an escape command therefor the next byte is a part
+      // 12 is an escape command therefore the next byte is a part
       // of this command
       if (b0 == 12)
       {

--- a/src/pdfdc.cpp
+++ b/src/pdfdc.cpp
@@ -569,7 +569,7 @@ bool
 wxPdfDCImpl::SetTransformMatrix(const wxAffineMatrix2D& matrix)
 {
   wxCHECK_MSG(m_pdfDocument, false, wxS("Invalid PDF DC"));
-  // At the moment concatinating the transformation matrix is not supported
+  // At the moment concatenating the transformation matrix is not supported
   ResetTransformMatrix();
 
   // Do nothing, if the transformation matrix equals the identity matrix

--- a/src/pdffontdataopentype.cpp
+++ b/src/pdffontdataopentype.cpp
@@ -209,7 +209,7 @@ wxPdfFontDataOpenTypeUnicode::LoadFontMetrics(wxXmlNode* root)
     else
     {
       m_initialized = false;
-      // usually this should not happen since file accessability was already checked
+      // usually this should not happen since file accessibility was already checked
       wxLogError(wxString(wxS("wxPdfFontDataOpenTypeUnicode::LoadFontMetrics: ")) +
                  wxString::Format(_("CTG file '%s' not found."), fileName.GetFullPath().c_str()));
     }
@@ -532,7 +532,7 @@ wxPdfFontDataOpenTypeUnicode::WriteFontData(wxOutputStream* fontData, wxPdfSorte
       }
       else
       {
-        // usually this should not happen since file accessability was already checked
+        // usually this should not happen since file accessibility was already checked
         wxLogError(wxString(wxS("wxPdfFontDataOpenTypeUnicode::WriteFontData: ")) +
                    wxString::Format(_("Font file '%s' not found."), fileName.GetFullPath().c_str()));
       }

--- a/src/pdffontdatatruetype.cpp
+++ b/src/pdffontdatatruetype.cpp
@@ -369,7 +369,7 @@ wxPdfFontDataTrueType::WriteFontData(wxOutputStream* fontData, wxPdfSortedArrayI
     }
     else
     {
-      // usually this should not happen since file accessability was already checked
+      // usually this should not happen since file accessibility was already checked
       wxLogError(wxString(wxS("wxPdfFontDataTrueType::WriteFontData: ")) +
                  wxString::Format(_("Font file '%s' not found."), fileName.GetFullPath().c_str()));
     }
@@ -602,7 +602,7 @@ wxPdfFontDataTrueTypeUnicode::LoadFontMetrics(wxXmlNode* root)
     else
     {
       m_initialized = false;
-      // usually this should not happen since file accessability was already checked
+      // usually this should not happen since file accessibility was already checked
       wxLogError(wxString(wxS("wxPdfFontDataTrueTypeUnicode::LoadFontMetrics: ")) +
                  wxString::Format(_("CTG file '%s' not found."), fileName.GetFullPath().c_str()));
     }
@@ -939,7 +939,7 @@ wxPdfFontDataTrueTypeUnicode::WriteFontData(wxOutputStream* fontData, wxPdfSorte
       }
       else
       {
-        // usually this should not happen since file accessability was already checked
+        // usually this should not happen since file accessibility was already checked
         wxLogError(wxString(wxS("wxPdfFontDataTrueTypeUnicode::WriteFontData: ")) +
                    wxString::Format(_("Font file '%s' not found."), fileName.GetFullPath().c_str()));
       }

--- a/src/pdffontparsertype1.cpp
+++ b/src/pdffontparsertype1.cpp
@@ -164,7 +164,7 @@ wxPdfFontParserType1::IdentifyFont(const wxString& fontFileName, int fontIndex)
   m_fileName = fontFileName;
   wxFileName fileNameFont(fontFileName);
 
-  // Check for existance of metric file
+  // Check for existence of metric file
   wxFSFile* metricFile = NULL;
   wxFileName fileNameMetric(fontFileName);
   fileNameMetric.SetExt(wxS("afm"));
@@ -1226,7 +1226,7 @@ wxPdfFontParserType1::ReadPFM(wxInputStream& pfmFile)
   }
   fd.SetItalicAngle(italicAngle);
 
-  // The .pfm file does not conatin the font bounding box.
+  // The .pfm file does not contain the font bounding box.
   // The font bounding box is reconstructed by guessing reasonable values.
   int bbox1 = (isMono) ? -20 : -100;
   int bbox2 = -(ext.descender+5);
@@ -1388,7 +1388,7 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
   if (m_isPFB)
   {
     // The private dictionary can be made of several segments
-    // All binary segements are read in and concatenated
+    // All binary segments are read in and concatenated
     unsigned char blocktype;
     int length;
     do

--- a/src/pdffontsubsetcff.cpp
+++ b/src/pdffontsubsetcff.cpp
@@ -1372,7 +1372,7 @@ wxPdfFontSubsetCff::FindLocalAndGlobalSubrsUsed()
         wxPdfSortedArrayInt hSubrsUsed(CompareInts);
         wxArrayInt lSubrsUsed;
         //Scans the Charsting data storing the used Local and Global subroutines
-        // by the glyphs. Scans the Subrs recursivley.
+        // by the glyphs. Scans the Subrs recursively.
         FindSubrsUsed(j, *((wxPdfCffIndexArray*) m_fdLocalSubrIndex[j]), hSubrsUsed, lSubrsUsed);
         // Builds the New Local Subrs index
         SubsetSubrs(*((wxPdfCffIndexArray*) m_fdLocalSubrIndex[j]), hSubrsUsed);
@@ -1383,11 +1383,11 @@ wxPdfFontSubsetCff::FindLocalAndGlobalSubrsUsed()
   else
   {
     //Scans the Charsting data storing the used Local and Global subroutines
-    // by the glyphs. Scans the Subrs recursivley.
+    // by the glyphs. Scans the Subrs recursively.
     FindSubrsUsed(-1, *m_localSubrIndex, *m_hLocalSubrsUsed, m_lLocalSubrsUsed);
   }
   // Subset the Global Subroutines
-  // Scan the Global Subr Hashmap recursivly on the Gsubrs
+  // Scan the Global Subr Hashmap recursively on the Gsubrs
   FindGlobalSubrsUsed();
   SubsetSubrs(*m_globalSubrIndex, *m_hGlobalSubrsUsed);
   if (!m_isCid)

--- a/src/pdfgraphics.cpp
+++ b/src/pdfgraphics.cpp
@@ -2548,7 +2548,7 @@ wxPdfDocument::Arrow(double x1, double y1, double x2, double y2, double linewidt
 
   SetLineWidth(0.2);
 
-  //Draw a arrow head
+  //Draw an arrow head
   OutAscii(wxPdfUtility::Double2String( x2*m_k,2) + wxString(wxS(" ")) +
            wxPdfUtility::Double2String( y2*m_k,2) + wxString(wxS(" m ")) +
            wxPdfUtility::Double2String( x3*m_k,2) + wxString(wxS(" ")) +

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -206,7 +206,7 @@ wxPdfImage::ConvertWxImage(const wxImage& image, bool jpegFormat)
 bool
 wxPdfImage::Parse()
 {
-  // Check whether this image originated from an wxImage and is valid
+  // Check whether this image originated from a wxImage and is valid
   if (m_fromWxImage) return m_validWxImage;
 
   bool isValid = false;
@@ -514,7 +514,7 @@ wxPdfImage::ParseJPG(wxInputStream* imageStream)
     if (lastMarker == M_COM && commentCorrection)
     {
       // some software does not count the length bytes of COM section
-      // one company doing so is very much envolved in JPEG... so we accept too
+      // one company doing so is very much involved in JPEG... so we accept too
       // by the way: some of those companies changed their code now...
       commentCorrection = 2;
     }
@@ -1177,7 +1177,7 @@ wxPdfImage::ReadIntLE(wxInputStream* imageStream)
 unsigned int
 wxPdfImage::ReadUIntBE(wxInputStream* imageStream)
 {
-  // Read a unsigned 4-byte integer from file (big endian)
+  // Read an unsigned 4-byte integer from file (big endian)
   unsigned int i32;
   imageStream->Read(&i32, 4);
   return wxUINT32_SWAP_ON_LE(i32);
@@ -1186,7 +1186,7 @@ wxPdfImage::ReadUIntBE(wxInputStream* imageStream)
 unsigned int
 wxPdfImage::ReadUIntLE(wxInputStream* imageStream)
 {
-  // Read a unsigned 4-byte integer from file (little endian)
+  // Read an unsigned 4-byte integer from file (little endian)
   unsigned int i32;
   imageStream->Read(&i32, 4);
   return wxUINT32_SWAP_ON_BE(i32);


### PR DESCRIPTION
A file with an e with acute wasn't encode as UTF-8 and wasn't displayed correctly in the Doxygen help.