### PR TITLE
Fix file encoding build issues

### DIFF
--- a/include/wx/pdfinfo.h
+++ b/include/wx/pdfinfo.h
@@ -74,7 +74,7 @@ public:
   const wxString GetModDate() const { return m_modDate; }
 
 private:
-  wxString m_title;        ///< The document’s title.
+  wxString m_title;        ///< The documentâ€™s title.
   wxString m_author;       ///< The name of the person who created the document.
   wxString m_subject;      ///< The subject of the document.
   wxString m_keywords;     ///< Keywords associated with the document.

--- a/samples/minimal/gradients.cpp
+++ b/samples/minimal/gradients.cpp
@@ -116,7 +116,7 @@ gradients(bool testMode)
   int coons1 = pdf.CoonsPatchGradient(mesh1);
   pdf.SetFillGradient(20,115,80,80,coons1);
 
-  // set the coordinates for the cubic Bézier points x1,y1 ... x12, y12 of the patch
+  // set the coordinates for the cubic BÃ©zier points x1,y1 ... x12, y12 of the patch
   // (see coons_patch_mesh_coords.jpg)
   wxPdfCoonsPatchMesh mesh2;
   wxPdfColour colors2[] = { yellow, blue, green, red };


### PR DESCRIPTION
Encoded files from Win-1252 to UTF-8 to fix build errors in MSVC2025 (illegal character warning).