### PR TITLE
Fix PDF silently rendering bold text with the regular font variant

### DIFF
--- a/src/pdfdc.cpp
+++ b/src/pdfdc.cpp
@@ -338,7 +338,7 @@ wxPdfDCImpl::SetFont(const wxFont& font)
     return;
   }
   int styles = wxPDF_FONTSTYLE_REGULAR;
-  if (font.GetWeight() == wxFONTWEIGHT_BOLD)
+  if (font.GetWeight() >= wxFONTWEIGHT_BOLD)
   {
     styles |= wxPDF_FONTSTYLE_BOLD;
   }

--- a/src/pdffontmanager.cpp
+++ b/src/pdffontmanager.cpp
@@ -1159,9 +1159,14 @@ wxPdfFontManagerBase::GetFont(const wxString& fontName, int fontStyle) const
     wxPdfFontNameMap::const_iterator fontIter = m_fontNameMap.find(lcFontName);
     if (fontIter != m_fontNameMap.end())
     {
-      fontData = m_fontList[fontIter->second]->GetFontData();
+      wxPdfFontData* candidate = m_fontList[fontIter->second]->GetFontData();
+      // only accept if no specific style was requested or the candidate's style matches
+      if (searchStyle == wxPDF_FONTSTYLE_REGULAR || candidate->GetStyle() == searchStyle)
+      {
+        fontData = candidate;
+      }
     }
-    else
+    if (fontData == NULL)
     {
       wxString style = ConvertStyleToString(searchStyle);
       wxLogDebug(wxString(wxS("wxPdfFontManagerBase::GetFont: ")) +

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -182,7 +182,7 @@ wxPdfDocument::SelectFont(const wxFont& font, bool setFont)
 {
 #if wxUSE_UNICODE
   int styles = wxPDF_FONTSTYLE_REGULAR;
-  if (font.GetWeight() == wxFONTWEIGHT_BOLD)
+  if (font.GetWeight() >= wxFONTWEIGHT_BOLD)
   {
     styles |= wxPDF_FONTSTYLE_BOLD;
   }
@@ -233,7 +233,7 @@ wxPdfDocument::SelectFont(const wxFont& font, bool setFont)
   }
 
   wxString style = wxEmptyString;
-  if (font.GetWeight() == wxFONTWEIGHT_BOLD)
+  if (font.GetWeight() >= wxFONTWEIGHT_BOLD)
   {
     style += wxString(wxS("B"));
   }


### PR DESCRIPTION
Also, Recognize bold styles such as `wxFONTWEIGHT_EXTRAHEAVY`.

Looks like Calibri Bold was the font I was trying to use, and was getting lost. After this fix, it appears great now.