### PR TITLE
Fix calculation in ScalePdfToFontMetric

### DIFF
--- a/src/pdfdc.cpp
+++ b/src/pdfdc.cpp
@@ -1791,7 +1791,7 @@ int
 wxPdfDCImpl::ScalePdfToFontMetric( double metric ) const
 {
   double fontScale = (72.0 / m_ppi) / (double)m_pdfDocument->GetScaleFactor();
-  return wxRound(((metric * m_signY) / m_scaleY ) / fontScale);
+  return wxRound((metric / m_scaleX) / fontScale);
 }
 
 void


### PR DESCRIPTION
Please let me know if I am wrong here, but I suspect that `ScalePdfToFontMetric`'s calculation was incidentally working, but using the wrong variables. First, I don't think `m_signY` should be used in here at all (since it is always -1 or 1, and a negative width doesn't make sense). Secondly, I believe it should be `m_scaleX` (not `m_scaleY`) since we are calculating width.

I ran through a few documents and this seems to look OK.