### PR TITLE
Fix clang warnings

### DIFF
--- a/include/wx/pdfcffdecoder.h
+++ b/include/wx/pdfcffdecoder.h
@@ -115,8 +115,6 @@ protected:
   int CalcHints(wxInputStream* stream, int begin, int end, int globalBias, int localBias, wxPdfCffIndexArray& localSubIndex);
 
 private:
-  wxInputStream*        m_stream;              ///< the input stream
-
   wxPdfCffIndexArray*   m_globalSubrIndex;     ///< index of the global subroutines
 
   int                   m_charstringType;      ///< charstring type (distinguishes type 1 and type 2 font formats)
@@ -125,7 +123,6 @@ private:
   wxPdfCffFontObject*   m_args;                ///< argument stack
   int                   m_argCount;            ///< argument count
 
-  int                   m_globalBias;          ///< The bias for the global subroutines
   int                   m_numHints;            ///< Number of arguments to the stem operators in a subroutine calculated recursively
 
   wxPdfSortedArrayInt*  m_hGlobalSubrsUsed;    ///< A HashMap for keeping the Global subroutines used in the font

--- a/include/wx/pdffontsubsetcff.h
+++ b/include/wx/pdffontsubsetcff.h
@@ -279,7 +279,6 @@ private:
   wxArrayInt            m_privateDictOffset;       ///< offsets in private dictionary
 
   int                   m_globalBias;              ///< The bias for the global subroutines
-  int                   m_numHints;                ///< Number of arguments to the stem operators in a subroutine calculated recursively
 
   wxPdfSortedArrayInt*  m_hGlobalSubrsUsed;        ///< A HashMap for keeping the Global subroutines used in the font
   wxArrayInt            m_lGlobalSubrsUsed;        ///< The Global SubroutinesUsed HashMaps as ArrayLists

--- a/include/wx/pdfpattern.h
+++ b/include/wx/pdfpattern.h
@@ -150,10 +150,6 @@ private:
 
   double m_width;      ///< pattern width
   double m_height;     ///< pattern height
-
-  double m_xStep;      ///< repeat offset in x direction
-  double m_yStep;      ///< repeat offset in y direction
-  double m_matrix[6];  ///< transformation matrix
 };
 
 #endif

--- a/include/wx/pdfshape.h
+++ b/include/wx/pdfshape.h
@@ -98,7 +98,6 @@ private:
   wxPdfArrayDouble m_x;       ///< array of abscissa values
   wxPdfArrayDouble m_y;       ///< array of ordinate values
   int              m_subpath; ///< subpath index
-  int              m_segment; ///< segment index
   int              m_index;   ///< points index
 };
 

--- a/include/wx/pdfxml.h
+++ b/include/wx/pdfxml.h
@@ -655,7 +655,6 @@ private:
   wxPdfDoubleHashMap m_colWidths;    ///< array of column widths
   wxPdfDoubleHashMap m_maxHeights;   ///< array of maximum row heights including row span heights
 
-  double             m_maxWidth;     ///< maximum allowed width
   double             m_totalWidth;   ///< total width
   double             m_bodyHeight;   ///< total height of table body
   double             m_headHeight;   ///< total height of table header

--- a/src/crypto/random.cpp
+++ b/src/crypto/random.cpp
@@ -211,7 +211,7 @@ read_urandom(void* buf, size_t n)
 {
   size_t i;
   ssize_t ret;
-  int fd, count;
+  int fd;
   struct stat st;
   int errnold = errno;
 

--- a/src/crypto/random.cpp
+++ b/src/crypto/random.cpp
@@ -211,7 +211,7 @@ read_urandom(void* buf, size_t n)
 {
   size_t i;
   ssize_t ret;
-  int fd;
+  int fd, count;
   struct stat st;
   int errnold = errno;
 

--- a/src/crypto/saslprep.cpp
+++ b/src/crypto/saslprep.cpp
@@ -1241,9 +1241,6 @@ saslprep(const std::string& intxt, std::string& outtxt)
   unsigned char* p;
   pg_wchar* wp;
 
-  /* Ensure we return *output as nullptr on failure */
-  char* output = nullptr;
-
   /*
    * Quick check if the input is pure ASCII.  An ASCII string requires no
    * further processing.

--- a/src/crypto/unicode_norm.cpp
+++ b/src/crypto/unicode_norm.cpp
@@ -208,7 +208,7 @@ recompose_code(uint32_t start, uint32_t code, uint32_t *result)
 
     int i;
 
-    for (i = 0; i < lengthof(UnicodeDecompMain); i++)
+    for (i = 0; i < (int)lengthof(UnicodeDecompMain); i++)
     {
       entry = &UnicodeDecompMain[i];
 

--- a/src/pdfbarcodezint.cpp
+++ b/src/pdfbarcodezint.cpp
@@ -39,7 +39,7 @@
 #include "upcean_ttf.h" // OCR-B subset (digits, "<", ">")
 
 static const int maxSegs = 256;
-static const int maxCLISegs = 10; // CLI restricted to 10 segments (including main data)
+// CLI is restricted to 10 segments (including main data)
 
 // Matches RGB(A) hex string or CMYK decimal "C,M,Y,K" percentage string
 static const wxRegEx colorRE("^([0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?)|(((100|[0-9]{0,2}),){3}(100|[0-9]{0,2}))$");
@@ -47,7 +47,6 @@ static const wxRegEx colorRE("^([0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?)|(((100|[0-9]{0,
 static const wxString normalFontFamily = "Arimo"; // Sans-serif metrically compatible with Arial
 static const wxString upceanFontFamily = "OCRB"; // Monospace OCR-B
 static const wxString fontFamilyError = "Arimo";
-static const int fontSizeError = 14; // Point size
 
 static int normalFontID = -2; // Use -2 as `addApplicationFontFromData()` returns -1 on error
 

--- a/src/pdfencrypt.cpp
+++ b/src/pdfencrypt.cpp
@@ -487,7 +487,7 @@ wxPdfEncrypt::HashV5(const std::string& password, const std::string& salt, const
                 wxPdfRijndael::Key16Bytes,
                 reinterpret_cast<unsigned char*>(const_cast<char*>(K.substr(16, 16).c_str())));
 
-    int len = m_aes->blockEncrypt(dataK1, lenData, dataE);
+    (void)m_aes->blockEncrypt(dataK1, lenData, dataE);
 
     // E16mod3 is equivalent to mod 3 of the first 16 bytes of E
     // taken as a (128-bit) big-endian number.
@@ -503,28 +503,28 @@ wxPdfEncrypt::HashV5(const std::string& password, const std::string& salt, const
     {
       case 0:
         {
-          sha256_state hash;
-          sha_init(hash);
-          sha_process(hash, dataE, lenData);
-          sha_done(hash, result);
+          sha256_state hash256;
+          sha_init(hash256);
+          sha_process(hash256, dataE, lenData);
+          sha_done(hash256, result);
           K = std::string(result, 32);
         }
         break;
       case 1:
         {
-          sha384_state hash;
-          sha_init(hash);
-          sha_process(hash, dataE, lenData);
-          sha_done(hash, result);
+          sha384_state hash384;
+          sha_init(hash384);
+          sha_process(hash384, dataE, lenData);
+          sha_done(hash384, result);
           K = std::string(result, 48);
         }
         break;
       case 2:
         {
-          sha512_state hash;
-          sha_init(hash);
-          sha_process(hash, dataE, lenData);
-          sha_done(hash, result);
+          sha512_state hash512;
+          sha_init(hash512);
+          sha_process(hash512, dataE, lenData);
+          sha_done(hash512, result);
           K = std::string(result, 64);
         }
         break;
@@ -592,7 +592,7 @@ wxPdfEncrypt::ComputeUandUEforV5(const std::string& userPassword, const std::str
               nullptr);
   unsigned char tempData[32];
   memcpy(tempData, encryptionKey.c_str(), 32);
-  int len = m_aes->blockEncrypt(tempData, 32, tempData);
+  (void)m_aes->blockEncrypt(tempData, 32, tempData);
   m_ue = std::string(reinterpret_cast<char*>(tempData), 32);
 }
 
@@ -615,7 +615,7 @@ wxPdfEncrypt::ComputeOandOEforV5(const std::string& ownerPassword, const std::st
               nullptr);
   unsigned char tempData[32];
   memcpy(tempData, encryptionKey.c_str(), 32);
-  int len = m_aes->blockEncrypt(tempData, 32, tempData);
+  (void)m_aes->blockEncrypt(tempData, 32, tempData);
   m_oe = std::string(reinterpret_cast<char*>(tempData), 32);
 }
 
@@ -651,7 +651,7 @@ wxPdfEncrypt::ComputePermsV5(const std::string& encryptionKey)
               reinterpret_cast<unsigned char*>(const_cast<char*>(encryptionKey.c_str())),
               wxPdfRijndael::Key32Bytes,
               nullptr);
-  int len = m_aes->blockEncrypt(perms, sizeof(perms), perms);
+  (void)m_aes->blockEncrypt(perms, sizeof(perms), perms);
   m_permsValue = std::string(reinterpret_cast<char*>(perms), sizeof(perms));
 }
 
@@ -788,7 +788,7 @@ wxPdfEncrypt::CheckEncryptionParametersV5(const wxString& password)
               nullptr);
   unsigned char tempData[32];
   memcpy(tempData, encryptedFileKey.c_str(), 32);
-  int len = m_aes->blockDecrypt(tempData, 32, tempData);
+  (void)m_aes->blockDecrypt(tempData, 32, tempData);
   std::string fileKey = std::string(reinterpret_cast<char*>(tempData), 32);
 
   // Decrypt Perms and check against expected value
@@ -820,7 +820,7 @@ wxPdfEncrypt::CheckEncryptionParametersV5(const wxString& password)
     nullptr);
   unsigned char perms[16];
   memcpy(perms, m_permsValue.c_str(), 16);
-  len = m_aes->blockDecrypt(perms, sizeof(perms), perms);
+  (void)m_aes->blockDecrypt(perms, sizeof(perms), perms);
   bool permsValid = (memcmp(perms, permsExpected, 12) == 0);
   ok = ok && permsValid;
 

--- a/src/pdffontparsertruetype.cpp
+++ b/src/pdffontparsertruetype.cpp
@@ -737,7 +737,6 @@ wxPdfFontParserTrueType::IdentifyFont(const wxFont& font)
 wxPdfFontData*
 wxPdfFontParserTrueType::IdentifyFont(const char* fontBuffer, size_t fontBufferSize)
 {
-  bool ok = true;
   wxPdfFontData* fontData = nullptr;
   m_fileName = wxEmptyString;
 
@@ -1356,10 +1355,10 @@ wxPdfFontParserTrueType::ReadMaps()
   entry = m_tableDirectory->find(wxS("post"));
   if (entry == m_tableDirectory->end())
   {
-    static double pi = 4. * atan(1.0);
+    static double my_pi = 4. * atan(1.0);
     double caretSlopeRun = (double) hhea.m_caretSlopeRun;
     double caretSlopeRise = (double) hhea.m_caretSlopeRise;
-    italicAngle = -atan2(caretSlopeRun, caretSlopeRise) * 180. / pi;
+    italicAngle = -atan2(caretSlopeRun, caretSlopeRise) * 180. / my_pi;
   }
   else
   {

--- a/src/pdffontparsertype1.cpp
+++ b/src/pdffontparsertype1.cpp
@@ -378,7 +378,6 @@ wxPdfFontParserType1::ReadAFM(wxInputStream& afmFile)
     fd.SetUnderlineThickness(50);
 
     wxPdfKernPairMap* kpMap = NULL;
-    wxString encodingScheme;
 
     bool hasCapHeight = false;
     bool hasXCapHeight = false;
@@ -390,8 +389,8 @@ wxPdfFontParserType1::ReadAFM(wxInputStream& afmFile)
 
     wxTextInputStream text(afmFile);
     wxString line;
-    wxString charcode, glyphname;
-    wxString code, param, dummy, glyph;
+    wxString glyphname;
+    wxString code, param;
     wxString token, tokenBoxHeight;
     long nParam;
     long cc, width, boxHeight, glyphNumber;
@@ -504,7 +503,7 @@ wxPdfFontParserType1::ReadAFM(wxInputStream& afmFile)
         }
         else if (code.IsSameAs(wxS("EncodingScheme")))
         {
-          encodingScheme = param;
+          //no-op
         }
         else if (code.IsSameAs(wxS("StartCharMetrics")))
         {
@@ -522,7 +521,7 @@ wxPdfFontParserType1::ReadAFM(wxInputStream& afmFile)
           tokenBoxHeight = wxEmptyString;
           // Character metrics
           param.ToLong(&cc);
-          dummy = tkz.GetNextToken(); // 2
+          (void)tkz.GetNextToken(); // 2
           while (tkz.HasMoreTokens())
           {
             token = tkz.GetNextToken();
@@ -530,7 +529,7 @@ wxPdfFontParserType1::ReadAFM(wxInputStream& afmFile)
             {
               param = tkz.GetNextToken(); // Width
               param.ToLong(&width);
-              dummy = tkz.GetNextToken(); // Semicolon
+              (void)tkz.GetNextToken(); // Semicolon
 
               if (!hasMissingWidth && glyphname.IsSameAs(wxS(".notdef")))
               {
@@ -542,22 +541,22 @@ wxPdfFontParserType1::ReadAFM(wxInputStream& afmFile)
             else if (token.IsSameAs(wxS("N"))) // Glyph name
             {
               glyphname = tkz.GetNextToken(); // Glyph name
-              dummy = tkz.GetNextToken(); // Semicolon
+              (void)tkz.GetNextToken(); // Semicolon
             }
             else if (token.IsSameAs(wxS("G"))) // Glyph number
             {
               param = tkz.GetNextToken(); // Number
               param.ToLong(&glyphNumber);
-              dummy = tkz.GetNextToken(); // Semicolon
+              (void)tkz.GetNextToken(); // Semicolon
             }
             else if (token.IsSameAs(wxS("B"))) // Character bounding box
             {
-              dummy = tkz.GetNextToken(); // x left
-              dummy = tkz.GetNextToken(); // y bottom
-              dummy = tkz.GetNextToken(); // x right
+              (void)tkz.GetNextToken(); // x left
+              (void)tkz.GetNextToken(); // y bottom
+              (void)tkz.GetNextToken(); // x right
               tokenBoxHeight = tkz.GetNextToken(); // y top
               tokenBoxHeight.ToLong(&boxHeight);
-              dummy = tkz.GetNextToken(); // Semicolon
+              (void)tkz.GetNextToken(); // Semicolon
 
               if (!tokenBoxHeight.IsEmpty())
               {
@@ -1210,8 +1209,6 @@ wxPdfFontParserType1::ReadPFM(wxInputStream& pfmFile)
     pfmFile.SeekI(hdr.face);
     ReadString(pfmFile);
   }
-
-  wxString encodingScheme = (hdr.charset != 0) ? wxString(wxS("FontSpecific")) : wxString(wxS("AdobeStandardEncoding"));
 
   int stemV = (hdr.weight > 475 ||
                fontNameLower.Find(wxS("bold")) != wxNOT_FOUND ||
@@ -2215,10 +2212,10 @@ wxPdfFontParserType1::ParseDict(wxInputStream* stream, int start, int length, bo
 }
 
 void
-wxPdfFontParserType1::ParseFontMatrix(wxInputStream* stream)
+wxPdfFontParserType1::ParseFontMatrix(wxInputStream* WXUNUSED(stream))
 {
-  wxString matrix = GetArray(stream);
 #if 0
+  wxString matrix = GetArray(stream);
   // If the font matrix is not [ 0.001 0 0 0.001 0 0]
   // font metrics need to be transformed accordingly
   int unitsPerEm;

--- a/src/pdffontparsertype1.cpp
+++ b/src/pdffontparsertype1.cpp
@@ -2212,10 +2212,10 @@ wxPdfFontParserType1::ParseDict(wxInputStream* stream, int start, int length, bo
 }
 
 void
-wxPdfFontParserType1::ParseFontMatrix(wxInputStream* WXUNUSED(stream))
+wxPdfFontParserType1::ParseFontMatrix(wxInputStream* stream)
 {
+  (void)GetArray(stream);
 #if 0
-  wxString matrix = GetArray(stream);
   // If the font matrix is not [ 0.001 0 0 0.001 0 0]
   // font metrics need to be transformed accordingly
   int unitsPerEm;

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -260,8 +260,6 @@ wxPdfDocument::SelectFont(const wxPdfFont& font, int style, double size, bool se
   if (font.IsValid())
   {
     m_decoration = style & wxPDF_FONTSTYLE_DECORATION_MASK;
-    int fontStyle = font.GetStyle();
-    fontStyle |= m_decoration;
     if (size <= 0)
     {
       size = m_fontSizePt;
@@ -1497,7 +1495,6 @@ wxPdfDocument::PutFonts()
       NewObj();
       Out("<</Type /FontDescriptor");
       OutAscii(wxString(wxS("/FontName /")) + name);
-      wxString s = wxEmptyString;
       OutAscii(wxString::Format(wxS("/Ascent %d"), fd.GetAscent()));
       OutAscii(wxString::Format(wxS("/Descent %d"), fd.GetDescent()));
       OutAscii(wxString::Format(wxS("/CapHeight %d"), fd.GetCapHeight()));

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -476,11 +476,10 @@ wxPdfParser::SetupDecryptor()
   }
 #endif
 
-  bool encryptMetaData = true;
   obj = enc->Get(wxS("EncryptMetadata"));
   if (obj && obj->GetType() == OBJTYPE_BOOLEAN)
   {
-    encryptMetaData = ((wxPdfBoolean*)obj)->GetValue();
+    (void)((wxPdfBoolean*)obj)->GetValue();
   }
 
   if (enc->IsCreatedIndirect())
@@ -1179,7 +1178,7 @@ wxPdfParser::ParseObject()
 
     default:
       {
-        wxString token = m_tokens->GetStringValue();
+        (void)m_tokens->GetStringValue();
         obj = new wxPdfLiteral(-type, m_tokens->GetStringValue());
       }
       break;

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -474,13 +474,14 @@ wxPdfParser::SetupDecryptor()
       // Handle entry
     }
   }
-#endif
 
+  bool encryptMetaData = true;
   obj = enc->Get(wxS("EncryptMetadata"));
   if (obj && obj->GetType() == OBJTYPE_BOOLEAN)
   {
-    (void)((wxPdfBoolean*)obj)->GetValue();
+    encryptMetaData = ((wxPdfBoolean*)obj)->GetValue();
   }
+#endif
 
   if (enc->IsCreatedIndirect())
   {

--- a/src/pdfpattern.cpp
+++ b/src/pdfpattern.cpp
@@ -23,17 +23,17 @@
 #include "wx/pdfpattern.h"
 
 wxPdfPattern::wxPdfPattern(int index, double width, double height)
-  : m_objIndex(0), m_index(index), m_width(width), m_height(height), m_patternStyle(wxPDF_PATTERNSTYLE_IMAGE)
+  : m_objIndex(0), m_index(index), m_patternStyle(wxPDF_PATTERNSTYLE_IMAGE), m_width(width), m_height(height)
 {
 }
 
 wxPdfPattern::wxPdfPattern(int index, double width, double height, int templateId)
-  : m_objIndex(0), m_index(index), m_width(width), m_height(height), m_patternStyle(wxPDF_PATTERNSTYLE_TEMPLATE), m_templateId(templateId)
+  : m_objIndex(0), m_index(index), m_patternStyle(wxPDF_PATTERNSTYLE_TEMPLATE), m_templateId(templateId), m_width(width), m_height(height)
 {
 }
 
 wxPdfPattern::wxPdfPattern(int index, double width, double height, wxPdfPatternStyle patternStyle, const wxColour& drawColour, const wxColour& fillColour)
-  : m_objIndex(0), m_index(index), m_width(width), m_height(height), m_patternStyle(patternStyle), m_drawColour(drawColour)
+  : m_objIndex(0), m_index(index), m_patternStyle(patternStyle), m_drawColour(drawColour), m_width(width), m_height(height)
 {
   m_hasFillColour = fillColour.IsOk();
   if (m_hasFillColour)

--- a/src/pdfutility.cpp
+++ b/src/pdfutility.cpp
@@ -92,7 +92,6 @@ wxPdfUtility::String2Double(const wxString& str, const wxString& defaultUnit, do
   };
   static wxString allowed[] = { "pt", "mm", "cm", "in", "px" };
   static wxArrayString allowedUnits(5, allowed);
-  static int ixPixel = allowedUnits.Index("px");
 
   wxString strValue = str.Strip(wxString::both);
   wxString valueUnit = (strValue.length() > 2) ? strValue.Right(2) : defaultUnit;

--- a/src/pdfxml.cpp
+++ b/src/pdfxml.cpp
@@ -721,7 +721,6 @@ wxPdfTable::GetLastRowsOnPage() const
     const double pageHeight = m_document->GetPageHeight();
     const double yMax = pageHeight - breakMargin;
     const double firstBodyRowHeight = iterBodyFirst->second;
-    const bool writeHeader = m_headRowLast > m_headRowFirst;
     const double topTotalMargin = m_document->GetTopMargin() + m_document->GetHeaderHeight() + m_headHeight;
     const double availablePageHeight = yMax - topTotalMargin;
     double y = m_document->GetY();
@@ -893,7 +892,6 @@ wxPdfDocument::PrepareXmlTable(wxXmlNode* node, wxPdfCellContext& context)
   double maxWidth = context.GetMaxWidth();
   wxPdfBoolHashMap cellused;
   int coldef = 0;
-  int colundef = 0;
   int row = 0;
   int col;
   int i, j;
@@ -929,7 +927,6 @@ wxPdfDocument::PrepareXmlTable(wxXmlNode* node, wxPdfCellContext& context)
           for (col = 0; col < colspan; col++)
           {
             table->SetColumnWidth(coldef++, colwidth);
-            if (colwidth <= 0) colundef++;
           }
         }
         colChild = colChild->GetNext();
@@ -1511,7 +1508,6 @@ wxPdfDocument::PrepareXmlCell(wxXmlNode* node, wxPdfCellContext& context)
         double len = 0;
         double ls = 0;
         int ns = 0;
-        int nl = 1;
         wxUniChar c = 0;
         while (i < nb)
         {
@@ -1526,7 +1522,6 @@ wxPdfDocument::PrepareXmlCell(wxXmlNode* node, wxPdfCellContext& context)
             j = i;
             len = 0;
             ns = 0;
-            nl++;
             context.MarkLastLine();
             context.AddLine();
             context.AddHeight(GetLineHeight());
@@ -1582,7 +1577,6 @@ wxPdfDocument::PrepareXmlCell(wxXmlNode* node, wxPdfCellContext& context)
             j = i;
             len = 0;
             ns = 0;
-            nl++;
             context.AddLine();
             context.AddHeight(GetLineHeight());
             wmax = context.GetMaxWidth();
@@ -2272,7 +2266,6 @@ wxPdfDocument::WriteXmlCell(wxXmlNode* node, wxPdfCellContext& context)
         int j = 0;
         double len = 0;
         int ns = 0;
-        int nl = 1;
         wxUniChar c;
         while (i < nb)
         {
@@ -2292,7 +2285,6 @@ wxPdfDocument::WriteXmlCell(wxXmlNode* node, wxPdfCellContext& context)
             j = i;
             len = 0;
             ns = 0;
-            nl++;
             context.IncrementCurrentLine();
             Ln();
             DoXmlAlign(context);
@@ -2337,7 +2329,6 @@ wxPdfDocument::WriteXmlCell(wxXmlNode* node, wxPdfCellContext& context)
             j = i;
             len = 0;
             ns = 0;
-            nl++;
             context.IncrementCurrentLine();
             Ln();
             DoXmlAlign(context);

--- a/src/woff/woffconverter.cpp
+++ b/src/woff/woffconverter.cpp
@@ -227,7 +227,7 @@ wxMemoryInputStream* WoffConverter::Convert(wxInputStream* fontStream)
     }
   }
 
-  if (outTableOffset != totalSfntSize)
+  if ((uint32_t)outTableOffset != totalSfntSize)
   {
     return nullptr;
   }
@@ -235,7 +235,6 @@ wxMemoryInputStream* WoffConverter::Convert(wxInputStream* fontStream)
   for (TableDirectory& td : tdList)
   {
     std::vector<uint8_t> compressedData(td.compLength);
-    std::vector<uint8_t> uncompressedData;
     ArrayCopy(fontData.data(), td.offset, compressedData.data(), 0, td.compLength);
     int expectedUncompressedLen = (int)td.origLengthVal;
     if (td.compLength > td.origLengthVal)
@@ -253,7 +252,7 @@ wxMemoryInputStream* WoffConverter::Convert(wxInputStream* fontStream)
       tblOut.Close();
       wxMemoryInputStream tblIn(tblOut);
 
-      wxFileOffset streamLen = tblIn.SeekI(0, wxFromEnd);
+      (void)tblIn.SeekI(0, wxFromEnd);
       std::vector<uint8_t> uncompressedData(expectedUncompressedLen);
       tblIn.SeekI(0, wxFromStart);
       tblIn.ReadAll(uncompressedData.data(), uncompressedData.size());


### PR DESCRIPTION
Removes unused variables, fixes shadow variables, adds casts, fixes initializer ordering.

I didn't touch the `thirdparty` folder, so still get a few unused var warnings from there unfortunately.