### PR TITLE
Add support for granular font weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and from version 0.9.0 onwards this project adheres to [Semantic Versioning](htt
 
 ## [Unreleased]
 
+### Added
+
+- Added support for granular font weights (Thin to ExtraHeavy)
+
+### Fixed
+
+- Fixed issue where bold fonts were not correctly selected when using `wxFont` with `wxFONTWEIGHT_BOLD`
+
 ## [1.3.1] - 2025-04-28
 
 ### Fixed

--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -1162,6 +1162,14 @@ public:
   *   \li BI or IB: bold italic
   *   \li O: overline
   *   \li S: strikethrough
+  *   \li T: thin
+  *   \li E: extra light
+  *   \li L: light
+  *   \li M: medium
+  *   \li D: demi / semi-bold
+  *   \li X: extra bold
+  *   \li H: heavy / black
+  *   \li A: extra heavy
   * \param file The font definition file. By default, the name is built from the family and style,
   *  in lower case with no space.
   * \see SetFont()
@@ -1232,6 +1240,14 @@ public:
   *   \li U: underline
   *   \li O: overline
   *   \li S: strikethrough
+  *   \li T: thin
+  *   \li E: extra light
+  *   \li L: light
+  *   \li M: medium
+  *   \li D: demi / semi-bold
+  *   \li X: extra bold
+  *   \li H: heavy / black
+  *   \li A: extra heavy
   * or any combination. The default value is regular. Bold and italic styles do not apply to Symbol and ZapfDingbats
   * \param size Font size in points. The default value is the current size. If no size has been
   * specified since the beginning of the document, the value taken is 12
@@ -1266,6 +1282,14 @@ public:
   *   \li wxPDF_FONTSTYLE_UNDERLINE  : underline
   *   \li wxPDF_FONTSTYLE_OVERLINE   : overline
   *   \li wxPDF_FONTSTYLE_STRIKEOUT  : strike through
+  *   \li wxPDF_FONTSTYLE_THIN       : thin
+  *   \li wxPDF_FONTSTYLE_EXTRALIGHT : extra light
+  *   \li wxPDF_FONTSTYLE_LIGHT      : light
+  *   \li wxPDF_FONTSTYLE_MEDIUM     : medium
+  *   \li wxPDF_FONTSTYLE_SEMIBOLD   : semi-bold
+  *   \li wxPDF_FONTSTYLE_EXTRABOLD  : extra bold
+  *   \li wxPDF_FONTSTYLE_HEAVY      : heavy
+  *   \li wxPDF_FONTSTYLE_EXTRAHEAVY : extra heavy
   * or any combination.
   * \param size Font size in points. The default value is the current size. If no size has been
   * specified since the beginning of the document, the value taken is 12
@@ -1285,6 +1309,14 @@ public:
   *   \li wxPDF_FONTSTYLE_UNDERLINE  : underline
   *   \li wxPDF_FONTSTYLE_OVERLINE   : overline
   *   \li wxPDF_FONTSTYLE_STRIKEOUT  : strike through
+  *   \li wxPDF_FONTSTYLE_THIN       : thin
+  *   \li wxPDF_FONTSTYLE_EXTRALIGHT : extra light
+  *   \li wxPDF_FONTSTYLE_LIGHT      : light
+  *   \li wxPDF_FONTSTYLE_MEDIUM     : medium
+  *   \li wxPDF_FONTSTYLE_SEMIBOLD   : semi-bold
+  *   \li wxPDF_FONTSTYLE_EXTRABOLD  : extra bold
+  *   \li wxPDF_FONTSTYLE_HEAVY      : heavy
+  *   \li wxPDF_FONTSTYLE_EXTRAHEAVY : extra heavy
   * or any combination. Bold and italic styles do not apply to Symbol and ZapfDingbats
   * \param size Font size in points. The default value is the current size. If no size has been
   * \see AddFont(), SetFont(), SetFontSize(), Cell(), MultiCell(), Write()
@@ -1337,6 +1369,14 @@ public:
   *   \li U: underline
   *   \li O: overline
   *   \li S: strikethrough
+  *   \li T: thin
+  *   \li E: extra light
+  *   \li L: light
+  *   \li M: medium
+  *   \li D: demi / semi-bold
+  *   \li X: extra bold
+  *   \li H: heavy / black
+  *   \li A: extra heavy
   * \see SetFont()
   */
   virtual const wxString GetFontStyle() const;

--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -1170,6 +1170,8 @@ public:
   *   \li X: extra bold
   *   \li H: heavy / black
   *   \li A: extra heavy
+  * Granular weights (Thin to ExtraHeavy) are fully supported when using @c wxFont
+  * starting with wxWidgets 3.1.2. In older versions, they fall back to the closest standard weight (Bold or Regular).
   * \param file The font definition file. By default, the name is built from the family and style,
   *  in lower case with no space.
   * \see SetFont()
@@ -1290,7 +1292,8 @@ public:
   *   \li wxPDF_FONTSTYLE_EXTRABOLD  : extra bold
   *   \li wxPDF_FONTSTYLE_HEAVY      : heavy
   *   \li wxPDF_FONTSTYLE_EXTRAHEAVY : extra heavy
-  * or any combination.
+  * or any combination. Granular weights (Thin to ExtraHeavy) are fully supported when using @c wxFont
+  * starting with wxWidgets 3.1.2. In older versions, they fall back to the closest standard weight (Bold or Regular).
   * \param size Font size in points. The default value is the current size. If no size has been
   * specified since the beginning of the document, the value taken is 12
   * \see AddFont(), SetFontSize(), Cell(), MultiCell(), Write()
@@ -1317,7 +1320,9 @@ public:
   *   \li wxPDF_FONTSTYLE_EXTRABOLD  : extra bold
   *   \li wxPDF_FONTSTYLE_HEAVY      : heavy
   *   \li wxPDF_FONTSTYLE_EXTRAHEAVY : extra heavy
-  * or any combination. Bold and italic styles do not apply to Symbol and ZapfDingbats
+  * or any combination. Granular weights (Thin to ExtraHeavy) are fully supported when using @c wxFont
+  * starting with wxWidgets 3.1.2. In older versions, they fall back to the closest standard weight (Bold or Regular).
+  * Bold and italic styles do not apply to Symbol and ZapfDingbats
   * \param size Font size in points. The default value is the current size. If no size has been
   * \see AddFont(), SetFont(), SetFontSize(), Cell(), MultiCell(), Write()
   */
@@ -1377,6 +1382,8 @@ public:
   *   \li X: extra bold
   *   \li H: heavy / black
   *   \li A: extra heavy
+  * Granular weights (Thin to ExtraHeavy) are fully supported when using @c wxFont
+  * starting with wxWidgets 3.1.2. In older versions, they fall back to the closest standard weight (Bold or Regular).
   * \see SetFont()
   */
   virtual const wxString GetFontStyle() const;

--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -1160,6 +1160,8 @@ public:
   *   \li B: bold
   *   \li I: italic
   *   \li BI or IB: bold italic
+  *   \li O: overline
+  *   \li S: strikethrough
   * \param file The font definition file. By default, the name is built from the family and style,
   *  in lower case with no space.
   * \see SetFont()
@@ -1228,6 +1230,8 @@ public:
   *   \li I: italic
   *   \li BI or IB: bold italic
   *   \li U: underline
+  *   \li O: overline
+  *   \li S: strikethrough
   * or any combination. The default value is regular. Bold and italic styles do not apply to Symbol and ZapfDingbats
   * \param size Font size in points. The default value is the current size. If no size has been
   * specified since the beginning of the document, the value taken is 12
@@ -1274,13 +1278,14 @@ public:
   * The font referenced by the wxFont object will be added to the document if necessary.
   *
   * \param font The font to be set.
-  * \param style Font style. Possible values are (case insensitive):
-  *   \li empty string: regular (default)
-  *   \li B: bold
-  *   \li I: italic
-  *   \li BI or IB: bold italic
-  *   \li U: underline
-  * or any combination. The default value is regular. Bold and italic styles do not apply to Symbol and ZapfDingbats
+  * \param style Font style. Possible values are:
+  *   \li wxPDF_FONTSTYLE_REGULAR    : regular (default)
+  *   \li wxPDF_FONTSTYLE_ITALIC     : italic
+  *   \li wxPDF_FONTSTYLE_BOLD       : bold
+  *   \li wxPDF_FONTSTYLE_UNDERLINE  : underline
+  *   \li wxPDF_FONTSTYLE_OVERLINE   : overline
+  *   \li wxPDF_FONTSTYLE_STRIKEOUT  : strike through
+  * or any combination. Bold and italic styles do not apply to Symbol and ZapfDingbats
   * \param size Font size in points. The default value is the current size. If no size has been
   * \see AddFont(), SetFont(), SetFontSize(), Cell(), MultiCell(), Write()
   */
@@ -1325,7 +1330,13 @@ public:
 
   /// Gets the style of the current font.
   /**
-  * \return The style of the current font as a string
+  * \return The style of the current font as a string.
+  * The string may contain any combination of the following characters:
+  *   \li B: bold
+  *   \li I: italic
+  *   \li U: underline
+  *   \li O: overline
+  *   \li S: strikethrough
   * \see SetFont()
   */
   virtual const wxString GetFontStyle() const;

--- a/include/wx/pdfproperties.h
+++ b/include/wx/pdfproperties.h
@@ -61,15 +61,41 @@ enum
   wxPDF_FONTSTYLE_OVERLINE   = 1 << 3,
   wxPDF_FONTSTYLE_STRIKEOUT  = 1 << 4,
 
+  wxPDF_FONTSTYLE_THIN       = 1 << 5,
+  wxPDF_FONTSTYLE_EXTRALIGHT = 1 << 6,
+  wxPDF_FONTSTYLE_LIGHT      = 1 << 7,
+  wxPDF_FONTSTYLE_MEDIUM     = 1 << 8,
+  wxPDF_FONTSTYLE_SEMIBOLD   = 1 << 9,
+  wxPDF_FONTSTYLE_EXTRABOLD  = 1 << 10,
+  wxPDF_FONTSTYLE_HEAVY      = 1 << 11,
+  wxPDF_FONTSTYLE_EXTRAHEAVY = 1 << 12,
+
   wxPDF_FONTSTYLE_DECORATION_MASK = wxPDF_FONTSTYLE_UNDERLINE |
                                     wxPDF_FONTSTYLE_OVERLINE  |
                                     wxPDF_FONTSTYLE_STRIKEOUT,  ///< Mask of decoration styles
+  wxPDF_FONTSTYLE_WEIGHT_MASK     = wxPDF_FONTSTYLE_BOLD       |
+                                    wxPDF_FONTSTYLE_THIN       |
+                                    wxPDF_FONTSTYLE_EXTRALIGHT |
+                                    wxPDF_FONTSTYLE_LIGHT      |
+                                    wxPDF_FONTSTYLE_MEDIUM     |
+                                    wxPDF_FONTSTYLE_SEMIBOLD   |
+                                    wxPDF_FONTSTYLE_EXTRABOLD  |
+                                    wxPDF_FONTSTYLE_HEAVY      |
+                                    wxPDF_FONTSTYLE_EXTRAHEAVY, ///< Mask of weight styles
   wxPDF_FONTSTYLE_MASK = wxPDF_FONTSTYLE_REGULAR   |
                          wxPDF_FONTSTYLE_ITALIC    |
                          wxPDF_FONTSTYLE_BOLD      |
                          wxPDF_FONTSTYLE_UNDERLINE |
                          wxPDF_FONTSTYLE_OVERLINE  |
-                         wxPDF_FONTSTYLE_STRIKEOUT
+                         wxPDF_FONTSTYLE_STRIKEOUT |
+                         wxPDF_FONTSTYLE_THIN       |
+                         wxPDF_FONTSTYLE_EXTRALIGHT |
+                         wxPDF_FONTSTYLE_LIGHT      |
+                         wxPDF_FONTSTYLE_MEDIUM     |
+                         wxPDF_FONTSTYLE_SEMIBOLD   |
+                         wxPDF_FONTSTYLE_EXTRABOLD  |
+                         wxPDF_FONTSTYLE_HEAVY      |
+                         wxPDF_FONTSTYLE_EXTRAHEAVY
 };
 
 /// Permission options

--- a/include/wx/pdfproperties.h
+++ b/include/wx/pdfproperties.h
@@ -61,6 +61,8 @@ enum
   wxPDF_FONTSTYLE_OVERLINE   = 1 << 3,
   wxPDF_FONTSTYLE_STRIKEOUT  = 1 << 4,
 
+  /// Granular weights (Thin to ExtraHeavy) are fully supported when using wxFont starting with wxWidgets 3.1.2.
+  /// In older versions, they fall back to the closest standard weight (Bold or Regular).
   wxPDF_FONTSTYLE_THIN       = 1 << 5,
   wxPDF_FONTSTYLE_EXTRALIGHT = 1 << 6,
   wxPDF_FONTSTYLE_LIGHT      = 1 << 7,

--- a/src/pdfdc.cpp
+++ b/src/pdfdc.cpp
@@ -352,10 +352,59 @@ wxPdfDCImpl::SetFont(const wxFont& font)
     return;
   }
   int styles = wxPDF_FONTSTYLE_REGULAR;
-  if (font.GetWeight() >= wxFONTWEIGHT_BOLD)
+  wxFontWeight weight = font.GetWeight();
+
+#if wxCHECK_VERSION(3,1,2)
+  if (weight >= wxFONTWEIGHT_EXTRAHEAVY)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_HEAVY)
+  {
+    styles |= wxPDF_FONTSTYLE_HEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRABOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRABOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_BOLD)
   {
     styles |= wxPDF_FONTSTYLE_BOLD;
   }
+  else if (weight >= wxFONTWEIGHT_SEMIBOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_SEMIBOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_MEDIUM)
+  {
+    styles |= wxPDF_FONTSTYLE_MEDIUM;
+  }
+  else if (weight >= wxFONTWEIGHT_NORMAL)
+  {
+    // Regular
+  }
+  else if (weight >= wxFONTWEIGHT_LIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRALIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRALIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_THIN)
+  {
+    styles |= wxPDF_FONTSTYLE_THIN;
+  }
+#else
+  if (weight >= wxFONTWEIGHT_BOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_BOLD;
+  }
+  else if (weight == wxFONTWEIGHT_LIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+#endif
   if (font.GetStyle() == wxFONTSTYLE_ITALIC)
   {
     styles |= wxPDF_FONTSTYLE_ITALIC;

--- a/src/pdfdocument.cpp
+++ b/src/pdfdocument.cpp
@@ -965,6 +965,38 @@ wxPdfDocument::GetFontStyle() const
   {
     style += wxString(wxS("S"));
   }
+  if (styles & wxPDF_FONTSTYLE_THIN)
+  {
+    style += wxString(wxS("T"));
+  }
+  if (styles & wxPDF_FONTSTYLE_EXTRALIGHT)
+  {
+    style += wxString(wxS("E"));
+  }
+  if (styles & wxPDF_FONTSTYLE_LIGHT)
+  {
+    style += wxString(wxS("L"));
+  }
+  if (styles & wxPDF_FONTSTYLE_MEDIUM)
+  {
+    style += wxString(wxS("M"));
+  }
+  if (styles & wxPDF_FONTSTYLE_SEMIBOLD)
+  {
+    style += wxString(wxS("D"));
+  }
+  if (styles & wxPDF_FONTSTYLE_EXTRABOLD)
+  {
+    style += wxString(wxS("X"));
+  }
+  if (styles & wxPDF_FONTSTYLE_HEAVY)
+  {
+    style += wxString(wxS("H"));
+  }
+  if (styles & wxPDF_FONTSTYLE_EXTRAHEAVY)
+  {
+    style += wxString(wxS("A"));
+  }
   return style;
 }
 

--- a/src/pdffontdata.cpp
+++ b/src/pdffontdata.cpp
@@ -335,17 +335,53 @@ wxPdfFontData::SetStyle(const wxString& style)
   bool italic = (lcStyle.Find(wxS("italic"))  != wxNOT_FOUND) ||
                 (lcStyle.Find(wxS("oblique")) != wxNOT_FOUND) ||
                 lcStyle.IsSameAs(wxS("i")) || lcStyle.IsSameAs(wxS("bi")) || lcStyle.IsSameAs(wxS("ib"));
-  bool bold = (lcStyle.Find(wxS("bold"))  != wxNOT_FOUND) ||
-              (lcStyle.Find(wxS("black")) != wxNOT_FOUND) ||
-              lcStyle.IsSameAs(wxS("b")) || lcStyle.IsSameAs(wxS("bi")) || lcStyle.IsSameAs(wxS("ib"));
   m_style = wxPDF_FONTSTYLE_REGULAR;
-  if (bold)
-  {
-    m_style |= wxPDF_FONTSTYLE_BOLD;
-  }
   if (italic)
   {
     m_style |= wxPDF_FONTSTYLE_ITALIC;
+  }
+
+  if (lcStyle.Find(wxS("extraheavy")) != wxNOT_FOUND || lcStyle.Find(wxS("extra-heavy")) != wxNOT_FOUND)
+  {
+    m_style |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+  }
+  else if (lcStyle.Find(wxS("heavy")) != wxNOT_FOUND || (lcStyle.Find(wxS("black")) != wxNOT_FOUND && lcStyle.Find(wxS("extra")) == wxNOT_FOUND))
+  {
+    m_style |= wxPDF_FONTSTYLE_HEAVY;
+  }
+  else if (lcStyle.Find(wxS("extrabold")) != wxNOT_FOUND || lcStyle.Find(wxS("extra-bold")) != wxNOT_FOUND ||
+           lcStyle.Find(wxS("ultrabold")) != wxNOT_FOUND || lcStyle.Find(wxS("ultra-bold")) != wxNOT_FOUND ||
+           lcStyle.IsSameAs(wxS("x")))
+  {
+    m_style |= wxPDF_FONTSTYLE_EXTRABOLD;
+  }
+  else if (lcStyle.Find(wxS("semibold")) != wxNOT_FOUND || lcStyle.Find(wxS("semi-bold")) != wxNOT_FOUND ||
+           lcStyle.Find(wxS("demi")) != wxNOT_FOUND || lcStyle.IsSameAs(wxS("d")))
+  {
+    m_style |= wxPDF_FONTSTYLE_SEMIBOLD;
+  }
+  else if (lcStyle.Find(wxS("bold")) != wxNOT_FOUND || lcStyle.IsSameAs(wxS("b")) ||
+           lcStyle.IsSameAs(wxS("bi")) || lcStyle.IsSameAs(wxS("ib")))
+  {
+    m_style |= wxPDF_FONTSTYLE_BOLD;
+  }
+  else if (lcStyle.Find(wxS("medium")) != wxNOT_FOUND || lcStyle.IsSameAs(wxS("m")))
+  {
+    m_style |= wxPDF_FONTSTYLE_MEDIUM;
+  }
+  else if (lcStyle.Find(wxS("extralight")) != wxNOT_FOUND || lcStyle.Find(wxS("extra-light")) != wxNOT_FOUND ||
+           lcStyle.Find(wxS("ultralight")) != wxNOT_FOUND || lcStyle.Find(wxS("ultra-light")) != wxNOT_FOUND ||
+           lcStyle.IsSameAs(wxS("e")))
+  {
+    m_style |= wxPDF_FONTSTYLE_EXTRALIGHT;
+  }
+  else if (lcStyle.Find(wxS("thin")) != wxNOT_FOUND || lcStyle.IsSameAs(wxS("t")))
+  {
+    m_style |= wxPDF_FONTSTYLE_THIN;
+  }
+  else if (lcStyle.Find(wxS("light")) != wxNOT_FOUND || lcStyle.IsSameAs(wxS("l")))
+  {
+    m_style |= wxPDF_FONTSTYLE_LIGHT;
   }
 }
 
@@ -881,13 +917,49 @@ wxPdfFontData::FindStyleFromName(const wxString& name)
 {
   int style = wxPDF_FONTSTYLE_REGULAR;
   wxString lcName = name.Lower();
-  if (lcName.Find(wxS("bold")) != wxNOT_FOUND)
-  {
-    style |= wxPDF_FONTSTYLE_BOLD;
-  }
   if (lcName.Find(wxS("italic")) != wxNOT_FOUND || lcName.Find(wxS("oblique")) != wxNOT_FOUND)
   {
     style |= wxPDF_FONTSTYLE_ITALIC;
+  }
+
+  if (lcName.Find(wxS("extraheavy")) != wxNOT_FOUND || lcName.Find(wxS("extra-heavy")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+  }
+  else if (lcName.Find(wxS("heavy")) != wxNOT_FOUND || (lcName.Find(wxS("black")) != wxNOT_FOUND && lcName.Find(wxS("extra")) == wxNOT_FOUND))
+  {
+    style |= wxPDF_FONTSTYLE_HEAVY;
+  }
+  else if (lcName.Find(wxS("extrabold")) != wxNOT_FOUND || lcName.Find(wxS("extra-bold")) != wxNOT_FOUND ||
+           lcName.Find(wxS("ultrabold")) != wxNOT_FOUND || lcName.Find(wxS("ultra-bold")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_EXTRABOLD;
+  }
+  else if (lcName.Find(wxS("semibold")) != wxNOT_FOUND || lcName.Find(wxS("semi-bold")) != wxNOT_FOUND ||
+           lcName.Find(wxS("demi")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_SEMIBOLD;
+  }
+  else if (lcName.Find(wxS("bold")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_BOLD;
+  }
+  else if (lcName.Find(wxS("medium")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_MEDIUM;
+  }
+  else if (lcName.Find(wxS("extralight")) != wxNOT_FOUND || lcName.Find(wxS("extra-light")) != wxNOT_FOUND ||
+           lcName.Find(wxS("ultralight")) != wxNOT_FOUND || lcName.Find(wxS("ultra-light")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_EXTRALIGHT;
+  }
+  else if (lcName.Find(wxS("thin")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_THIN;
+  }
+  else if (lcName.Find(wxS("light")) != wxNOT_FOUND)
+  {
+    style |= wxPDF_FONTSTYLE_LIGHT;
   }
   return style;
 }

--- a/src/pdffontmanager.cpp
+++ b/src/pdffontmanager.cpp
@@ -1166,6 +1166,51 @@ wxPdfFontManagerBase::GetFont(const wxString& fontName, int fontStyle) const
         fontData = candidate;
       }
     }
+
+    // Fallback for granular weights: if a specific weight was requested, but not found,
+    // try to find the closest standard weight (Bold for Medium and above, Regular otherwise)
+    if (fontData == NULL && (searchStyle & wxPDF_FONTSTYLE_WEIGHT_MASK) > wxPDF_FONTSTYLE_BOLD)
+    {
+      const int weight = searchStyle & wxPDF_FONTSTYLE_WEIGHT_MASK;
+      // Map Medium and above to Bold; map anything lighter than Medium to Regular
+      const int fallbackStyle = (searchStyle & wxPDF_FONTSTYLE_ITALIC) | (weight >= wxPDF_FONTSTYLE_MEDIUM ? wxPDF_FONTSTYLE_BOLD : wxPDF_FONTSTYLE_REGULAR);
+      familyIter = m_fontFamilyMap.find(lcFontName);
+      if (familyIter == m_fontFamilyMap.end())
+        familyIter = familyAliasIter;
+      if (familyIter != m_fontFamilyMap.end())
+      {
+        // First, search within the font family (including aliases)
+        size_t n = familyIter->second.GetCount();
+        size_t j;
+        do
+        {
+          for (j = 0; j < n && fontData == NULL; ++j)
+          {
+            wxPdfFontData* data = m_fontList[familyIter->second[j]]->GetFontData();
+            if (data->GetStyle() == fallbackStyle)
+              fontData = data;
+          }
+          n = 0;
+          if (fontData == NULL && familyAliasIter != familyIter && familyAliasIter != m_fontFamilyMap.end())
+          {
+            familyIter = familyAliasIter;
+            n = familyIter->second.GetCount();
+          }
+        } while (n > 0);
+      }
+      if (fontData == NULL)
+      {
+        // If still not found, check if a font was registered directly under this name with the fallback style
+        wxPdfFontNameMap::const_iterator fontIter = m_fontNameMap.find(lcFontName);
+        if (fontIter != m_fontNameMap.end())
+        {
+          wxPdfFontData* candidate = m_fontList[fontIter->second]->GetFontData();
+          if (candidate->GetStyle() == fallbackStyle)
+            fontData = candidate;
+        }
+      }
+    }
+
     if (fontData == NULL)
     {
       wxString style = ConvertStyleToString(searchStyle);

--- a/src/pdffontmanager.cpp
+++ b/src/pdffontmanager.cpp
@@ -1186,13 +1186,49 @@ wxPdfFontManagerBase::GetFont(const wxString& fontName, const wxString& fontStyl
   wxString localStyle = fontStyle.Lower();
   if (localStyle.length() > 2)
   {
-    if (localStyle.Find(wxS("bold")) != wxNOT_FOUND)
-    {
-      style |= wxPDF_FONTSTYLE_BOLD;
-    }
     if (localStyle.Find(wxS("italic")) != wxNOT_FOUND || localStyle.Find(wxS("oblique")) != wxNOT_FOUND)
     {
       style |= wxPDF_FONTSTYLE_ITALIC;
+    }
+
+    if (localStyle.Find(wxS("extraheavy")) != wxNOT_FOUND || localStyle.Find(wxS("extra-heavy")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+    }
+    else if (localStyle.Find(wxS("heavy")) != wxNOT_FOUND || localStyle.Find(wxS("black")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_HEAVY;
+    }
+    else if (localStyle.Find(wxS("extrabold")) != wxNOT_FOUND || localStyle.Find(wxS("extra-bold")) != wxNOT_FOUND ||
+             localStyle.Find(wxS("ultrabold")) != wxNOT_FOUND || localStyle.Find(wxS("ultra-bold")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_EXTRABOLD;
+    }
+    else if (localStyle.Find(wxS("semibold")) != wxNOT_FOUND || localStyle.Find(wxS("semi-bold")) != wxNOT_FOUND ||
+             localStyle.Find(wxS("demi")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_SEMIBOLD;
+    }
+    else if (localStyle.Find(wxS("bold")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_BOLD;
+    }
+    else if (localStyle.Find(wxS("medium")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_MEDIUM;
+    }
+    else if (localStyle.Find(wxS("extralight")) != wxNOT_FOUND || localStyle.Find(wxS("extra-light")) != wxNOT_FOUND ||
+             localStyle.Find(wxS("ultralight")) != wxNOT_FOUND || localStyle.Find(wxS("ultra-light")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_EXTRALIGHT;
+    }
+    else if (localStyle.Find(wxS("thin")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_THIN;
+    }
+    else if (localStyle.Find(wxS("light")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_LIGHT;
     }
   }
   else
@@ -1204,6 +1240,38 @@ wxPdfFontManagerBase::GetFont(const wxString& fontName, const wxString& fontStyl
     if (localStyle.Find(wxS("i")) != wxNOT_FOUND)
     {
       style |= wxPDF_FONTSTYLE_ITALIC;
+    }
+    if (localStyle.Find(wxS("t")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_THIN;
+    }
+    if (localStyle.Find(wxS("e")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_EXTRALIGHT;
+    }
+    if (localStyle.Find(wxS("l")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_LIGHT;
+    }
+    if (localStyle.Find(wxS("m")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_MEDIUM;
+    }
+    if (localStyle.Find(wxS("d")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_SEMIBOLD;
+    }
+    if (localStyle.Find(wxS("x")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_EXTRABOLD;
+    }
+    if (localStyle.Find(wxS("h")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_HEAVY;
+    }
+    if (localStyle.Find(wxS("a")) != wxNOT_FOUND)
+    {
+      style |= wxPDF_FONTSTYLE_EXTRAHEAVY;
     }
   }
   return GetFont(fontName, style);
@@ -1325,19 +1393,48 @@ wxString
 wxPdfFontManagerBase::ConvertStyleToString(int fontStyle)
 {
   wxString style = wxEmptyString;
-  if ((fontStyle & wxPDF_FONTSTYLE_BOLDITALIC) == wxPDF_FONTSTYLE_BOLDITALIC)
+  if (fontStyle & wxPDF_FONTSTYLE_BOLD)
   {
-    style = wxString(_("BoldItalic"));
+    style += wxString(_("Bold"));
   }
-  else if (fontStyle & wxPDF_FONTSTYLE_BOLD)
+  if (fontStyle & wxPDF_FONTSTYLE_ITALIC)
   {
-    style = wxString(_("Bold"));
+    style += wxString(_("Italic"));
   }
-  else if (fontStyle & wxPDF_FONTSTYLE_ITALIC)
+  if (fontStyle & wxPDF_FONTSTYLE_THIN)
   {
-    style = wxString(_("Italic"));
+    style += wxString(_("Thin"));
   }
-  else
+  if (fontStyle & wxPDF_FONTSTYLE_EXTRALIGHT)
+  {
+    style += wxString(_("ExtraLight"));
+  }
+  if (fontStyle & wxPDF_FONTSTYLE_LIGHT)
+  {
+    style += wxString(_("Light"));
+  }
+  if (fontStyle & wxPDF_FONTSTYLE_MEDIUM)
+  {
+    style += wxString(_("Medium"));
+  }
+  if (fontStyle & wxPDF_FONTSTYLE_SEMIBOLD)
+  {
+    style += wxString(_("SemiBold"));
+  }
+  if (fontStyle & wxPDF_FONTSTYLE_EXTRABOLD)
+  {
+    style += wxString(_("ExtraBold"));
+  }
+  if (fontStyle & wxPDF_FONTSTYLE_HEAVY)
+  {
+    style += wxString(_("Heavy"));
+  }
+  if (fontStyle & wxPDF_FONTSTYLE_EXTRAHEAVY)
+  {
+    style += wxString(_("ExtraHeavy"));
+  }
+
+  if (style.IsEmpty())
   {
     style = wxString(_("Regular"));
   }

--- a/src/pdffontmanager.cpp
+++ b/src/pdffontmanager.cpp
@@ -641,8 +641,11 @@ wxPdfFontManagerBase::RegisterFont(const wxFont& font, const wxString& aliasName
     if (!AddFont(fontData, regFont))
     {
       delete fontData;
-      wxLogDebug(wxString(wxS("wxPdfFontManagerBase::RegisterFont: ")) +
-                 wxString::Format(_("wxFont '%s' already registered."), font.GetFaceName().c_str()));
+      if (!font.GetFaceName().StartsWith(wxS(".")))
+      {
+        wxLogDebug(wxString(wxS("wxPdfFontManagerBase::RegisterFont: ")) +
+                   wxString::Format(_("wxFont '%s' already registered."), font.GetFaceName().c_str()));
+      }
     }
   }
 #elif defined(__WXGTK__)
@@ -773,8 +776,11 @@ wxPdfFontManagerBase::RegisterFont(const wxFont& font, const wxString& aliasName
     if (!AddFont(fontData, regFont))
     {
       delete fontData;
-      wxLogDebug(wxString(wxS("wxPdfFontManagerBase::RegisterFont: ")) +
-                 wxString::Format(_("wxFont '%s' already registered."), font.GetFaceName().c_str()));
+      if (!font.GetFaceName().StartsWith(wxS(".")))
+      {
+        wxLogDebug(wxString(wxS("wxPdfFontManagerBase::RegisterFont: ")) +
+                   wxString::Format(_("wxFont '%s' already registered."), font.GetFaceName().c_str()));
+      }
     }
   }
 #elif wxPDFMACOSX_HAS_ATSU_TEXT
@@ -1211,7 +1217,7 @@ wxPdfFontManagerBase::GetFont(const wxString& fontName, int fontStyle) const
       }
     }
 
-    if (fontData == NULL)
+    if (fontData == NULL && !fontName.StartsWith(wxS(".")))
     {
       wxString style = ConvertStyleToString(searchStyle);
       wxLogDebug(wxString(wxS("wxPdfFontManagerBase::GetFont: ")) +

--- a/src/pdffontmanager.cpp
+++ b/src/pdffontmanager.cpp
@@ -1175,7 +1175,7 @@ wxPdfFontManagerBase::GetFont(const wxString& fontName, int fontStyle) const
 
     // Fallback for granular weights: if a specific weight was requested, but not found,
     // try to find the closest standard weight (Bold for Medium and above, Regular otherwise)
-    if (fontData == NULL && (searchStyle & wxPDF_FONTSTYLE_WEIGHT_MASK) > wxPDF_FONTSTYLE_BOLD)
+    if (fontData == NULL && (searchStyle & wxPDF_FONTSTYLE_WEIGHT_MASK) > wxPDF_FONTSTYLE_BOLD && !fontName.StartsWith(wxS(".")))
     {
       const int weight = searchStyle & wxPDF_FONTSTYLE_WEIGHT_MASK;
       // Map Medium and above to Bold; map anything lighter than Medium to Regular

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -156,6 +156,38 @@ wxPdfDocument::SelectFont(const wxString& family, const wxString& style, double 
   {
     styles |= wxPDF_FONTSTYLE_STRIKEOUT;
   }
+  if (ucStyle.Find(wxS('T')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_THIN;
+  }
+  if (ucStyle.Find(wxS('E')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRALIGHT;
+  }
+  if (ucStyle.Find(wxS('L')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+  if (ucStyle.Find(wxS('M')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_MEDIUM;
+  }
+  if (ucStyle.Find(wxS('D')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_SEMIBOLD;
+  }
+  if (ucStyle.Find(wxS('X')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRABOLD;
+  }
+  if (ucStyle.Find(wxS('H')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_HEAVY;
+  }
+  if (ucStyle.Find(wxS('A')) >= 0)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+  }
   return SelectFont(family, styles, size, setFont);
 }
 
@@ -182,10 +214,59 @@ wxPdfDocument::SelectFont(const wxFont& font, bool setFont)
 {
 #if wxUSE_UNICODE
   int styles = wxPDF_FONTSTYLE_REGULAR;
-  if (font.GetWeight() >= wxFONTWEIGHT_BOLD)
+  wxFontWeight weight = font.GetWeight();
+
+#if wxCHECK_VERSION(3,1,2)
+  if (weight >= wxFONTWEIGHT_EXTRAHEAVY)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_HEAVY)
+  {
+    styles |= wxPDF_FONTSTYLE_HEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRABOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRABOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_BOLD)
   {
     styles |= wxPDF_FONTSTYLE_BOLD;
   }
+  else if (weight >= wxFONTWEIGHT_SEMIBOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_SEMIBOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_MEDIUM)
+  {
+    styles |= wxPDF_FONTSTYLE_MEDIUM;
+  }
+  else if (weight >= wxFONTWEIGHT_NORMAL)
+  {
+    // Regular
+  }
+  else if (weight >= wxFONTWEIGHT_LIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRALIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRALIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_THIN)
+  {
+    styles |= wxPDF_FONTSTYLE_THIN;
+  }
+#else
+  if (weight >= wxFONTWEIGHT_BOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_BOLD;
+  }
+  else if (weight == wxFONTWEIGHT_LIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+#endif
   if (font.GetStyle() == wxFONTSTYLE_ITALIC)
   {
     styles |= wxPDF_FONTSTYLE_ITALIC;


### PR DESCRIPTION
I kept the current font management system intact and just expanded it, so internally "heavy" will be 'H', etc.

Some examples:

`legend->GetFont().SetWeight(wxFONTWEIGHT_THIN);`

<img width="210" height="134" alt="Screenshot 2026-05-06 at 6 53 17 AM" src="https://github.com/user-attachments/assets/0865dcde-20e0-48e0-8e21-7c1668a696f0" />

`legend->GetFont().SetWeight(wxFONTWEIGHT_EXTRAHEAVY);`

<img width="207" height="123" alt="Screenshot 2026-05-06 at 6 52 16 AM" src="https://github.com/user-attachments/assets/5eeb06d4-851d-45d2-9f12-86394a55cb1a" />

Closes #107