### PR TITLE
Improvements to DC/GC stack management

### DIFF
--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -1344,6 +1344,9 @@ public:
   */
   virtual void SetFontSize(double size);
 
+  /// Force selecting the current font
+  virtual void ForceCurrentFont();
+
   /// Returns the current font.
   /**
   * \return The current font.
@@ -2816,9 +2819,6 @@ protected:
   * \return TRUE if font was selected, FALSE otherwise
   */
   virtual bool SelectFont(const wxPdfFont& font, int style, double size = 0, bool setFont = true);
-
-  /// Force selecting the current font
-  virtual void ForceCurrentFont();
 
   /// Defines the size of the current font.
   /**

--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -1345,6 +1345,7 @@ public:
   virtual void SetFontSize(double size);
 
   /// Force selecting the current font
+  /// \private
   virtual void ForceCurrentFont();
 
   /// Returns the current font.

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ on the FPDF web site are incorporated into wxPdfDocument.
 
 - **Comprehensive Font Support**: Use standard Adobe fonts, Type1, TrueType, OpenType, and WOFF/WOFF2 fonts. Supports font embedding, subsetting, and Unicode (including CJK, Indic, and Right-to-Left scripts).
 - **Accessibility**: Generates selectable and searchable text, ensuring compatibility with screen readers and compliance with accessibility standards (ADA/WCAG)—unlike many "Print to PDF" solutions that render text as unsearchable graphics.
-- **Advanced Graphics**: Support for primitives, Bezier splines, transformations, clipping, transparency (alpha channel), patterns, and gradients. Includes `wxPdfGraphicsContext` for high-quality vector graphics.
+- **Advanced Graphics**: Support for primitives, Bézier splines, transformations, clipping, transparency (alpha channel), patterns, and gradients. Includes `wxPdfGraphicsContext` for high-quality vector graphics.
 - **Image Support**: Embed PNG, JPEG, GIF, and WMF images directly, or use any `wxImage` compatible format.
 - **Barcodes**: Built-in support for 1D barcodes and extensive 2D barcode support via the Zint library.
 - **Interactive Features**: Create bookmarks, internal/external links, annotations, and PDF forms.

--- a/src/pdfdc.cpp
+++ b/src/pdfdc.cpp
@@ -485,16 +485,10 @@ wxPdfDCImpl::DestroyClippingRegion()
   if (m_clipping)
   {
     m_pdfDocument->UnsetClipping();
-    {
-      wxPen x(GetPen()); SetPen(x);
+    m_pdfPen = wxNullPen;
+    m_pdfBrush = wxNullBrush;
+    m_pdfDocument->ForceCurrentFont();
     }
-    {
-      wxBrush x(GetBrush()); SetBrush(x);
-    }
-    {
-      wxFont x(GetFont()); m_pdfDocument->SetFont(x);
-    }
-  }
   ResetClipping();
 }
 
@@ -715,6 +709,7 @@ wxPdfDCImpl::ResetTransformMatrix()
     m_inTransform = false;
     m_pdfPen = m_pdfPenSaved;
     m_pdfBrush = m_pdfBrushSaved;
+    m_pdfDocument->ForceCurrentFont();
   }
 }
 #endif // wxUSE_DC_TRANSFORM_MATRIX
@@ -1183,6 +1178,8 @@ wxPdfDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y, doubl
     if (angle != 0)
     {
       m_pdfDocument->StopTransform();
+      m_pdfBrush = wxNullBrush;
+      m_pdfDocument->ForceCurrentFont();
     }
   }
 
@@ -1198,6 +1195,9 @@ wxPdfDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y, doubl
   }
 
   m_pdfDocument->StopTransform();
+  m_pdfPen = wxNullPen;
+  m_pdfBrush = wxNullBrush;
+  m_pdfDocument->ForceCurrentFont();
 
   if (*fontToUse != old)
   {

--- a/src/pdfdc.cpp
+++ b/src/pdfdc.cpp
@@ -205,12 +205,17 @@ wxPdfDCImpl::Init()
   m_graphicContext = NULL;
 #endif
 
-#if wxCHECK_VERSION(3,1,5)
+#if wxCHECK_VERSION(3,1,5) && !defined(__WXMSW__)
   wxDisplay display;
   m_ppiPdfFont = display.GetPPI().GetHeight();
 #else
   wxScreenDC screendc;
   m_ppiPdfFont = screendc.GetPPI().GetHeight();
+#endif
+#if defined(__WXMAC__) || defined(__WXOSX__)
+  // On macOS, the logical resolution is always 72 DPI, regardless of Retina scaling.
+  // wxDisplay::GetPPI() returns the physical resolution, so we force 72 here.
+  m_ppiPdfFont = 72;
 #endif
 
   m_mappingModeStyle = wxPDF_MAPMODESTYLE_STANDARD;
@@ -488,7 +493,7 @@ wxPdfDCImpl::DestroyClippingRegion()
     m_pdfPen = wxNullPen;
     m_pdfBrush = wxNullBrush;
     m_pdfDocument->ForceCurrentFont();
-    }
+  }
   ResetClipping();
 }
 

--- a/src/pdfgc.cpp
+++ b/src/pdfgc.cpp
@@ -1651,7 +1651,7 @@ wxPdfGraphicsContext::EndDoc()
 }
 
 void
-wxPdfGraphicsContext::StartPage(wxDouble width, wxDouble height)
+wxPdfGraphicsContext::StartPage(wxDouble WXUNUSED(width), wxDouble WXUNUSED(height))
 {
   if (!m_templateMode && m_pdfDocument != NULL)
   {
@@ -2314,7 +2314,7 @@ wxPdfGraphicsContext::GetTextExtent(const wxString& str,
   }
 }
 
-void wxPdfGraphicsContext::GetPartialTextExtents(const wxString& text, wxArrayDouble& widths) const
+void wxPdfGraphicsContext::GetPartialTextExtents(const wxString& WXUNUSED(text), wxArrayDouble& widths) const
 {
   wxLogDebug(wxT("wxPdfGraphicsContext::GetPartialTextExtents - not implemented"));
   widths.Clear();

--- a/src/pdfgc.cpp
+++ b/src/pdfgc.cpp
@@ -1768,10 +1768,14 @@ void wxPdfGraphicsContext::Clip(const wxPdfShape& shape)
 void wxPdfGraphicsContext::ResetClip()
 {
   if (!m_pdfDocument) return;
-  m_pdfDocument->UnsetClipping();
-  // UnsetClipping typically clears the entire stack of q/Q clips
-  // in wxPdfDocument, so we reset our count.
-  m_clipCount = 0;
+  // Unset all clips added at this level.
+  // Each Clip() call emits a 'q' and increments m_clipCount,
+  // so we must call StopTransform() (which emits 'Q') for each.
+  while (m_clipCount > 0)
+  {
+    m_pdfDocument->StopTransform();
+    m_clipCount--;
+  }
 }
 
 void wxPdfGraphicsContext::GetClipBox(wxDouble* x, wxDouble* y,

--- a/src/pdfgc.cpp
+++ b/src/pdfgc.cpp
@@ -1651,12 +1651,11 @@ wxPdfGraphicsContext::EndDoc()
 }
 
 void
-wxPdfGraphicsContext::StartPage(wxDouble WXUNUSED(width), wxDouble WXUNUSED(height))
+wxPdfGraphicsContext::StartPage(wxDouble width, wxDouble height)
 {
   if (!m_templateMode && m_pdfDocument != NULL)
   {
     // Begin a new page
-    // Library needs it this way (always landscape) to size the page correctly
     m_pdfDocument->AddPage(m_printData.GetOrientation());
     wxPdfLineStyle style = m_pdfDocument->GetLineStyle();
     style.SetWidth(1.0);


### PR DESCRIPTION
Invalidates that pens, brushes, and fonts after transformations (e.g., clipping) are complete. This ensures that they are reset properly after these operations are finished. Before, I would have a stale brush re-applied after a complex series of clippings (instead of the correct one).

Also ensures that the font is the correct PPI under Retina display when resetting it.