### PR TITLE
Allow wxPdfGraphicsRenderer to work from a wxPdfDocument

### DIFF
--- a/include/wx/pdfgc.h
+++ b/include/wx/pdfgc.h
@@ -69,6 +69,13 @@ public:
   /// @param data The print data to configure the document.
   wxPdfGraphicsContext(wxGraphicsRenderer* renderer, const wxPrintData& data);
 
+  /// Construct a context that draws into an existing wxPdfDocument.
+  /// The context does not own the document.
+  /// @param renderer Pointer to the graphics renderer.
+  /// @param pdfDocument Pointer to the existing PDF document.
+  wxPdfGraphicsContext(wxGraphicsRenderer* renderer,
+                       wxPdfDocument* pdfDocument);
+
   /// Construct a context that draws into an existing wxPdfDocument as a
   /// template region. The context does not own the document.
   /// @param renderer Pointer to the graphics renderer.
@@ -432,8 +439,8 @@ public:
   virtual ~wxPdfGraphicsRenderer() {}
 
   /// Returns the process-wide PDF graphics renderer.
-  /// @return A pointer to the singleton @c wxGraphicsRenderer.
-  static wxGraphicsRenderer* GetPdfRenderer();
+  /// @return A pointer to the singleton @c wxPdfGraphicsRenderer.
+  static wxPdfGraphicsRenderer* GetPdfRenderer();
 
   // PDF-specific factories --------------------------------------------------
 
@@ -449,6 +456,12 @@ public:
   /// @param dc The wxPdfDC to draw into.
   /// @return A pointer to the created @c wxGraphicsContext.
   wxGraphicsContext* CreateContext(wxPdfDC* dc);
+
+  /// Creates a context that draws into the given existing PDF document.
+  /// The context does not take ownership of the document.
+  /// @param pdfDocument The PDF document to draw into.
+  /// @return A pointer to the created @c wxGraphicsContext.
+  wxGraphicsContext* CreateContext(wxPdfDocument* pdfDocument);
 
   /// Creates a context that draws into the given existing PDF document as
   /// a template region of the given size. The context does not take

--- a/samples/pdfgc/pdfgc.cpp
+++ b/samples/pdfgc/pdfgc.cpp
@@ -35,6 +35,7 @@
 #include <wx/printdlg.h>
 
 #include "wx/pdfdc.h"
+#include "wx/pdfgc.h"
 
 #include "pdfgc.h"
 #include "pdfgc_bitmap.xpm"
@@ -340,11 +341,12 @@ int MyApp::OnExit()
 // ---------------------------------------------------------------------------
 
 wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
-    EVT_MENU(PdfGc_SavePdf,       MyFrame::OnSavePdf)
-    EVT_MENU(PdfGc_Print,         MyFrame::OnPrint)
-    EVT_MENU(PdfGc_PageSetup,     MyFrame::OnPageSetup)
-    EVT_MENU(wxID_EXIT,           MyFrame::OnExit)
-    EVT_MENU(wxID_ABOUT,          MyFrame::OnAbout)
+    EVT_MENU(PdfGc_SavePdf,           MyFrame::OnSavePdf)
+    EVT_MENU(PdfGc_SavePdfStandAlone, MyFrame::OnSavePdfStandAlone)
+    EVT_MENU(PdfGc_Print,             MyFrame::OnPrint)
+    EVT_MENU(PdfGc_PageSetup,         MyFrame::OnPageSetup)
+    EVT_MENU(wxID_EXIT,               MyFrame::OnExit)
+    EVT_MENU(wxID_ABOUT,              MyFrame::OnAbout)
 wxEND_EVENT_TABLE()
 
 MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
@@ -353,7 +355,8 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
     SetIcon(wxICON(mondrian));
 
     wxMenu* fileMenu = new wxMenu;
-    fileMenu->Append(PdfGc_SavePdf,      "&Save as PDF...\tCtrl+S");
+    fileMenu->Append(PdfGc_SavePdf,           "Save as PDF (via wxPdfDC)...\tCtrl+S");
+    fileMenu->Append(PdfGc_SavePdfStandAlone, "Save as PDF (Stand-alone GC)...\tCtrl+Shift+S");
     fileMenu->AppendSeparator();
     fileMenu->Append(PdfGc_Print,        "&Print...\tCtrl+P");
     fileMenu->Append(PdfGc_PageSetup,    "Page Set&up...");
@@ -418,6 +421,49 @@ void MyFrame::OnSavePdf(wxCommandEvent& WXUNUSED(event))
     }
 
     SetStatusText("Saved: " + outPath);
+
+    wxFileType* ft = wxTheMimeTypesManager->GetFileTypeFromExtension("pdf");
+    if (ft)
+    {
+        const wxString cmd = ft->GetOpenCommand(outPath);
+        if (!cmd.IsEmpty())
+            wxExecute(cmd);
+        delete ft;
+    }
+}
+
+void MyFrame::OnSavePdfStandAlone(wxCommandEvent& WXUNUSED(event))
+{
+    wxFileDialog dlg(this, "Save as PDF (Stand-alone GC)", wxEmptyString, "pdfgc_standalone.pdf",
+                     "PDF files (*.pdf)|*.pdf",
+                     wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    const wxString outPath = dlg.GetPath();
+
+    {
+        wxPdfDocument doc(wxPORTRAIT, "pt", wxPAPER_LETTER);
+        doc.Open();
+        doc.AddPage();
+
+        // Create a stand-alone graphics context for the document.
+        wxGraphicsContext* gc = wxPdfGraphicsRenderer::GetPdfRenderer()->CreateContext(&doc);
+        if (gc)
+        {
+            DrawScene(*gc,
+                      wxSize(PDFGC_SCENE_WIDTH, PDFGC_SCENE_HEIGHT));
+            delete gc;
+        }
+        else
+        {
+            wxLogError("wxPdfGraphicsRenderer::CreateContext(&doc) returned null.");
+        }
+
+        doc.SaveAsFile(outPath);
+    }
+
+    SetStatusText("Saved (Stand-alone): " + outPath);
 
     wxFileType* ft = wxTheMimeTypesManager->GetFileTypeFromExtension("pdf");
     if (ft)

--- a/samples/pdfgc/pdfgc.h
+++ b/samples/pdfgc/pdfgc.h
@@ -31,6 +31,7 @@ public:
     MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size);
 
     void OnSavePdf(wxCommandEvent& event);
+    void OnSavePdfStandAlone(wxCommandEvent& event);
     void OnPrint(wxCommandEvent& event);
     void OnPageSetup(wxCommandEvent& event);
     void OnExit(wxCommandEvent& event);
@@ -67,6 +68,7 @@ public:
 enum
 {
     PdfGc_SavePdf = wxID_HIGHEST + 1,
+    PdfGc_SavePdfStandAlone,
     PdfGc_Print,
     PdfGc_PageSetup
 };

--- a/src/pdfgc.cpp
+++ b/src/pdfgc.cpp
@@ -1576,6 +1576,16 @@ wxPdfGraphicsContext::wxPdfGraphicsContext(wxGraphicsRenderer* renderer, const w
   SetPrintData(data);
 }
 
+wxPdfGraphicsContext::wxPdfGraphicsContext(wxGraphicsRenderer* renderer, wxPdfDocument* pdfDocument)
+  : wxGraphicsContext(renderer)
+{
+  Init();
+  m_pdfDocument = pdfDocument;
+  m_templateMode = true;
+  m_templateWidth = 0.0;
+  m_templateHeight = 0.0;
+}
+
 wxPdfGraphicsContext::wxPdfGraphicsContext(wxGraphicsRenderer* renderer, wxPdfDocument* pdfDocument, double templateWidth, double templateHeight)
   : wxGraphicsContext(renderer)
 {
@@ -2727,7 +2737,7 @@ wxPdfGraphicsContext::CalculateFontMetrics(wxPdfFontDescription* desc, double po
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxPdfGraphicsRenderer, wxGraphicsRenderer);
 
-wxGraphicsRenderer*
+wxPdfGraphicsRenderer*
 wxPdfGraphicsRenderer::GetPdfRenderer()
 {
   static wxPdfGraphicsRenderer s_renderer;
@@ -2760,6 +2770,12 @@ wxPdfGraphicsRenderer::CreateContext(wxPdfDC* dc)
   return new wxPdfGraphicsContext(this, pdfDocument,
                                   static_cast<double>(width),
                                   static_cast<double>(height));
+}
+
+wxGraphicsContext*
+wxPdfGraphicsRenderer::CreateContext(wxPdfDocument* pdfDocument)
+{
+  return new wxPdfGraphicsContext(this, pdfDocument);
 }
 
 wxGraphicsContext*

--- a/src/pdfgc.cpp
+++ b/src/pdfgc.cpp
@@ -745,10 +745,58 @@ wxPdfGraphicsFontData::wxPdfGraphicsFontData(wxGraphicsRenderer* renderer, const
 
   m_font = font;
   m_styles = wxPDF_FONTSTYLE_REGULAR;
-  if (font.GetWeight() == wxFONTWEIGHT_BOLD)
+  wxFontWeight weight = font.GetWeight();
+#if wxCHECK_VERSION(3,1,2)
+  if (weight >= wxFONTWEIGHT_EXTRAHEAVY)
+  {
+    m_styles |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_HEAVY)
+  {
+    m_styles |= wxPDF_FONTSTYLE_HEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRABOLD)
+  {
+    m_styles |= wxPDF_FONTSTYLE_EXTRABOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_BOLD)
   {
     m_styles |= wxPDF_FONTSTYLE_BOLD;
   }
+  else if (weight >= wxFONTWEIGHT_SEMIBOLD)
+  {
+    m_styles |= wxPDF_FONTSTYLE_SEMIBOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_MEDIUM)
+  {
+    m_styles |= wxPDF_FONTSTYLE_MEDIUM;
+  }
+  else if (weight >= wxFONTWEIGHT_NORMAL)
+  {
+    // Regular
+  }
+  else if (weight >= wxFONTWEIGHT_LIGHT)
+  {
+    m_styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRALIGHT)
+  {
+    m_styles |= wxPDF_FONTSTYLE_EXTRALIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_THIN)
+  {
+    m_styles |= wxPDF_FONTSTYLE_THIN;
+  }
+#else
+  if (weight >= wxFONTWEIGHT_BOLD)
+  {
+    m_styles |= wxPDF_FONTSTYLE_BOLD;
+  }
+  else if (weight == wxFONTWEIGHT_LIGHT)
+  {
+    m_styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+#endif
   if (font.GetStyle() == wxFONTSTYLE_ITALIC)
   {
     m_styles |= wxPDF_FONTSTYLE_ITALIC;
@@ -792,10 +840,58 @@ wxPdfGraphicsFontData::wxPdfGraphicsFontData(wxGraphicsRenderer* renderer,
 
   m_font = font;
   int styles = wxPDF_FONTSTYLE_REGULAR;
-  if (font.GetWeight() == wxFONTWEIGHT_BOLD)
+  wxFontWeight weight = font.GetWeight();
+#if wxCHECK_VERSION(3,1,2)
+  if (weight >= wxFONTWEIGHT_EXTRAHEAVY)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRAHEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_HEAVY)
+  {
+    styles |= wxPDF_FONTSTYLE_HEAVY;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRABOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRABOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_BOLD)
   {
     styles |= wxPDF_FONTSTYLE_BOLD;
   }
+  else if (weight >= wxFONTWEIGHT_SEMIBOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_SEMIBOLD;
+  }
+  else if (weight >= wxFONTWEIGHT_MEDIUM)
+  {
+    styles |= wxPDF_FONTSTYLE_MEDIUM;
+  }
+  else if (weight >= wxFONTWEIGHT_NORMAL)
+  {
+    // Regular
+  }
+  else if (weight >= wxFONTWEIGHT_LIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_EXTRALIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_EXTRALIGHT;
+  }
+  else if (weight >= wxFONTWEIGHT_THIN)
+  {
+    styles |= wxPDF_FONTSTYLE_THIN;
+  }
+#else
+  if (weight >= wxFONTWEIGHT_BOLD)
+  {
+    styles |= wxPDF_FONTSTYLE_BOLD;
+  }
+  else if (weight == wxFONTWEIGHT_LIGHT)
+  {
+    styles |= wxPDF_FONTSTYLE_LIGHT;
+  }
+#endif
   if (font.GetStyle() == wxFONTSTYLE_ITALIC)
   {
     styles |= wxPDF_FONTSTYLE_ITALIC;


### PR DESCRIPTION
This allows for not having to create a `wxPdfDC `to get access to GC methods.

Now you can do something like:

```
wxPdfDocument doc(wxPORTRAIT, "pt", wxPAPER_LETTER);
doc.Open();
doc.AddPage();

wxGraphicsContext* gc = wxPdfGraphicsRenderer::GetPdfRenderer()->CreateContext(&doc);
if (gc)
...
```

Sample updated to show different ways to work with `wxPdfGraphicsContext`.

Closes #108 