### PR TITLE
Correctly handle supplementary Unicode characters

### DIFF
--- a/makefont/makefont.cpp
+++ b/makefont/makefont.cpp
@@ -1045,7 +1045,21 @@ MakeFont::WriteToUnicode(GlyphList& glyphs, wxMemoryOutputStream& toUnicode)
     size--;
     GlyphListEntry* entry = glyphs[k];
     wxString fromTo = wxString::Format(wxS("<%04x>"), entry->m_gid);
-    wxString uniChr = wxString::Format(wxS("<%04x>"), entry->m_uid);
+    wxString uniChr;
+    // PDF ToUnicode CMaps require UTF-16BE; supplementary characters (> U+FFFF)
+    // must be encoded as surrogate pairs, not as raw code points.
+    if (entry->m_uid > 0xFFFF)
+    {
+      // 0xD800/0xDC00: surrogate base offsets; 10-bit shift splits the 20-bit offset
+      wxUint32 cp   = entry->m_uid - 0x10000;
+      wxUint32 high = 0xD800 + (cp >> 10);
+      wxUint32 low  = 0xDC00 + (cp & 0x3FF);
+      uniChr = wxString::Format(wxS("<%04x%04x>"), high, low);
+    }
+    else
+    {
+      uniChr = wxString::Format(wxS("<%04x>"), entry->m_uid);
+    }
     WriteStreamBuffer(toUnicode, fromTo.ToAscii());
     WriteStreamBuffer(toUnicode, fromTo.ToAscii());
     WriteStreamBuffer(toUnicode, uniChr.ToAscii());

--- a/src/pdffontdata.cpp
+++ b/src/pdffontdata.cpp
@@ -1020,7 +1020,21 @@ wxPdfFontData::WriteToUnicode(wxPdfGlyphList& glyphs, wxMemoryOutputStream& toUn
     size--;
     wxPdfGlyphListEntry* entry = glyphs[k];
     wxString fromTo = wxString::Format(gidFormat, entry->m_gid);
-    wxString uniChr = wxString::Format(wxS("<%04x>"), entry->m_uid);
+    wxString uniChr;
+    // PDF ToUnicode CMaps require UTF-16BE; supplementary characters (> U+FFFF)
+    // must be encoded as surrogate pairs, not as raw code points.
+    if (entry->m_uid > 0xFFFF)
+    {
+      // 0xD800/0xDC00: surrogate base offsets; 10-bit shift splits the 20-bit offset
+      wxUint32 cp   = entry->m_uid - 0x10000;
+      wxUint32 high = 0xD800 + (cp >> 10);
+      wxUint32 low  = 0xDC00 + (cp & 0x3FF);
+      uniChr = wxString::Format(wxS("<%04x%04x>"), high, low);
+    }
+    else
+    {
+      uniChr = wxString::Format(wxS("<%04x>"), entry->m_uid);
+    }
     WriteStreamBuffer(toUnicode, fromTo.ToAscii());
     WriteStreamBuffer(toUnicode, fromTo.ToAscii());
     WriteStreamBuffer(toUnicode, uniChr.ToAscii());


### PR DESCRIPTION
If you have surrogate paired values (e.g., newer emojis) in your text, then it will not be written correctly to the stream. The PDF may render correctly, but if you copy it from the PDF and paste into something else it will be corrupted.

To reproduce:

- Set the font of the `wxPDFDocument` to "Segoe UI Emoji"
- Write out "🏐 WOMEN'S VOLLEYBALL"
- Open the PDF and it should look OK
- Copy the text in the PDF and paste into a text editor.

Before the fix, you will see **"㴀 WOMEN'S VOLLEYBALL"** in the pasted-into text editor. After this fix, you should see **"🏐 WOMEN'S VOLLEYBALL"**.
