### PR TITLE
clang-tidy warning fixes

### DIFF
--- a/src/pdfdecode.cpp
+++ b/src/pdfdecode.cpp
@@ -223,6 +223,13 @@ wxPdfParser::DecodePredictor(wxMemoryOutputStream* osIn, wxPdfObject* dicPar)
 
   int bytesPerPixel = colours * bpc / 8;
   int bytesPerRow = (colours * width * bpc + 7) / 8;
+
+  if (bytesPerRow < bytesPerPixel)
+  {
+    delete osOut;
+    return osIn;
+  }
+
   char* curr = new char[bytesPerRow];
   char* prior = new char[bytesPerRow];
 

--- a/src/pdfdecode.cpp
+++ b/src/pdfdecode.cpp
@@ -218,17 +218,16 @@ wxPdfParser::DecodePredictor(wxMemoryOutputStream* osIn, wxPdfObject* dicPar)
     return osIn;
   }
 
-  wxMemoryInputStream dataStream(*osIn);
-  wxMemoryOutputStream* osOut = new wxMemoryOutputStream();;
-
   int bytesPerPixel = colours * bpc / 8;
   int bytesPerRow = (colours * width * bpc + 7) / 8;
 
   if (bytesPerRow < bytesPerPixel)
   {
-    delete osOut;
     return osIn;
   }
+
+  wxMemoryInputStream dataStream(*osIn);
+  wxMemoryOutputStream* osOut = new wxMemoryOutputStream();;
 
   char* curr = new char[bytesPerRow];
   char* prior = new char[bytesPerRow];

--- a/src/pdfdecode.cpp
+++ b/src/pdfdecode.cpp
@@ -213,6 +213,11 @@ wxPdfParser::DecodePredictor(wxMemoryOutputStream* osIn, wxPdfObject* dicPar)
     bpc = ((wxPdfNumber*) obj)->GetInt();
   }
 
+  if (width <= 0 || colours <= 0 || bpc <= 0)
+  {
+    return osIn;
+  }
+
   wxMemoryInputStream dataStream(*osIn);
   wxMemoryOutputStream* osOut = new wxMemoryOutputStream();;
 
@@ -479,6 +484,10 @@ wxPdfLzwDecoder::WriteString(int code)
 void
 wxPdfLzwDecoder::AddStringToTable(int oldCode, char newString)
 {
+  if (m_tableIndex >= WXPDF_LZW_STRINGTABLE_SIZE)
+  {
+    return;
+  }
   size_t j;
   size_t length = m_stringTable[oldCode].GetCount();
   m_stringTable[m_tableIndex].Empty();

--- a/src/pdfdecode.cpp
+++ b/src/pdfdecode.cpp
@@ -129,7 +129,7 @@ wxPdfParser::ASCII85Decode(wxMemoryOutputStream* osIn)
     if (state == 5)
     {
       state = 0;
-      int r = 0;
+      unsigned int r = 0;
       for (int j = 0; j < 5; ++j)
       {
         r = r * 85 + chn[j];
@@ -140,7 +140,7 @@ wxPdfParser::ASCII85Decode(wxMemoryOutputStream* osIn)
       osOut->PutC((char)( r        & 0xff));
     }
   }
-  int r = 0;
+  unsigned int r = 0;
   if (state == 1)
   {
     wxLogError(wxString(wxS("wxPdfParser::ASCII85Decode: ")) +

--- a/src/pdffontparsertruetype.cpp
+++ b/src/pdffontparsertruetype.cpp
@@ -1587,7 +1587,7 @@ wxPdfFontParserTrueType::ReadFormat4()
   SkipBytes(2);
   int segCount = ReadUShort() / 2;
   int glyphIdCount = tableLength / 2 - 8 - segCount * 4;
-  if (glyphIdCount < 0)
+  if (segCount <= 0 || glyphIdCount < 0)
   {
     delete h;
     return NULL;

--- a/src/pdffontparsertruetype.cpp
+++ b/src/pdffontparsertruetype.cpp
@@ -1587,6 +1587,11 @@ wxPdfFontParserTrueType::ReadFormat4()
   SkipBytes(2);
   int segCount = ReadUShort() / 2;
   int glyphIdCount = tableLength / 2 - 8 - segCount * 4;
+  if (glyphIdCount < 0)
+  {
+    delete h;
+    return NULL;
+  }
   SkipBytes(6);
 
   int* endCount   = new int[segCount];
@@ -1639,7 +1644,6 @@ wxPdfFontParserTrueType::ReadFormat4()
       r->m_width = GetGlyphWidth(r->m_glyph);
       int idx = m_fontSpecific ? ((j & 0xff00) == 0xf000 ? j & 0xff : j) : j;
       (*h)[idx] = r;
-//      wxLogMessage(wxS("C %ld G %ld"), idx, glyph);
     }
   }
 

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -376,7 +376,7 @@ wxPdfImage::ParsePNG(wxInputStream* imageStream)
         if (n >= 2)
         {
         m_trns[0] = t[1];
-      }
+        }
       }
       else if (ct == 2)
       {
@@ -387,7 +387,7 @@ wxPdfImage::ParsePNG(wxInputStream* imageStream)
         m_trns[0] = t[1];
         m_trns[1] = t[3];
         m_trns[2] = t[5];
-      }
+        }
       }
       else
       {

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -373,15 +373,21 @@ wxPdfImage::ParsePNG(wxInputStream* imageStream)
       {
         m_trnsSize = 1;
         m_trns = new char[1];
+        if (n >= 2)
+        {
         m_trns[0] = t[1];
+      }
       }
       else if (ct == 2)
       {
         m_trnsSize = 3;
         m_trns = new char[3];
+        if (n >= 6)
+        {
         m_trns[0] = t[1];
         m_trns[1] = t[3];
         m_trns[2] = t[5];
+      }
       }
       else
       {

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -350,6 +350,11 @@ wxPdfImage::ParsePNG(wxInputStream* imageStream)
   do
   {
     n = ReadIntBE(imageStream);
+    if (n < 0)
+    {
+      // Invalid chunk size
+      break;
+    }
     imageStream->Read(buffer,4);
     if (strncmp(buffer,"PLTE",4) == 0)
     {
@@ -603,7 +608,7 @@ wxPdfImage::ParseJPG(wxInputStream* imageStream)
           // anything else isn't interesting
           off_t pos = (unsigned int) ReadUShortBE(imageStream);
           pos = pos-2;
-          if (pos)
+          if (pos > 0)
           {
             imageStream->SeekI(pos, wxFromCurrent);
           }

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -372,7 +372,7 @@ wxPdfImage::ParsePNG(wxInputStream* imageStream)
       if (ct == 0)
       {
         m_trnsSize = 1;
-        m_trns = new char[1];
+        m_trns = new char[1]();
         if (n >= 2)
         {
         m_trns[0] = t[1];
@@ -381,7 +381,7 @@ wxPdfImage::ParsePNG(wxInputStream* imageStream)
       else if (ct == 2)
       {
         m_trnsSize = 3;
-        m_trns = new char[3];
+        m_trns = new char[3]();
         if (n >= 6)
         {
         m_trns[0] = t[1];

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -1195,7 +1195,10 @@ wxPdfParser::ResolveObject(wxPdfObject* obj)
     wxPdfIndirectReference* ref = (wxPdfIndirectReference*)obj;
     int idx = ref->GetNumber();
     obj = ParseSpecificObject(idx);
+    if (obj != NULL)
+    {
     obj->SetCreatedIndirect(true);
+  }
   }
   return obj;
 }
@@ -1276,8 +1279,10 @@ wxPdfParser::ParseDirectObject(int k)
   {
     m_objNum = k;
     m_objGen = 0;
+    if (obj != NULL && obj->GetType() == OBJTYPE_STREAM)
+    {
     wxPdfStream* objStream = (wxPdfStream*) obj;
-    obj = ParseObjectStream((wxPdfStream*) obj, m_xref[k].m_ofs_idx);
+      obj = ParseObjectStream(objStream, m_xref[k].m_ofs_idx);
     if (m_cacheObjects)
     {
       if (!isCached)
@@ -1290,14 +1295,20 @@ wxPdfParser::ParseDirectObject(int k)
       delete objStream;
     }
   }
+    else
+    {
+      // Object not found or not a stream
+      obj = NULL;
+    }
+  }
 
   if (obj != NULL)
   {
     obj->SetObjNum(m_objNum, m_objGen);
-  }
   if (obj->GetType() == OBJTYPE_STREAM)
   {
     GetStreamBytes((wxPdfStream*) obj);
+  }
   }
   return obj;
 }

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -960,44 +960,52 @@ wxPdfParser::ParseXRefStream(int ptr, bool setTrailer)
     {
       wxPdfXRefEntry& xrefEntry = m_xref[start];
       int type = 1;
-      if (wc[0] > 0)
+      if (bptr + wc[0] + wc[1] + wc[2] <= (int) inLength)
       {
-        type = 0;
-        for (k = 0; k < wc[0]; ++k)
+        if (wc[0] > 0)
         {
-          type = (type << 8) + (buffer[bptr++] & 0xff);
+          type = 0;
+          for (k = 0; k < wc[0]; ++k)
+          {
+            type = (type << 8) + (buffer[bptr++] & 0xff);
+          }
+        }
+        int field2 = 0;
+        for (k = 0; k < wc[1]; ++k)
+        {
+          field2 = (field2 << 8) + (buffer[bptr++] & 0xff);
+        }
+        int field3 = 0;
+        for (k = 0; k < wc[2]; ++k)
+        {
+          field3 = (field3 << 8) + (buffer[bptr++] & 0xff);
+        }
+        if (xrefEntry.m_ofs_idx == 0 && xrefEntry.m_gen_ref == 0)
+        {
+          switch (type)
+          {
+            case 0:
+              xrefEntry.m_type = 0;
+              xrefEntry.m_ofs_idx = -1;
+              xrefEntry.m_gen_ref = 0;
+              break;
+            case 1:
+              xrefEntry.m_type = 1;
+              xrefEntry.m_ofs_idx = field2;
+              xrefEntry.m_gen_ref = field3;
+              break;
+            case 2:
+              xrefEntry.m_type = 2;
+              xrefEntry.m_ofs_idx = field3;
+              xrefEntry.m_gen_ref = field2;
+              break;
+          }
         }
       }
-      int field2 = 0;
-      for (k = 0; k < wc[1]; ++k)
+      else
       {
-        field2 = (field2 << 8) + (buffer[bptr++] & 0xff);
-      }
-      int field3 = 0;
-      for (k = 0; k < wc[2]; ++k)
-      {
-        field3 = (field3 << 8) + (buffer[bptr++] & 0xff);
-      }
-      if (xrefEntry.m_ofs_idx == 0 && xrefEntry.m_gen_ref == 0)
-      {
-        switch (type)
-        {
-          case 0:
-            xrefEntry.m_type = 0;
-            xrefEntry.m_ofs_idx = -1;
-            xrefEntry.m_gen_ref = 0;
-            break;
-          case 1:
-            xrefEntry.m_type = 1;
-            xrefEntry.m_ofs_idx = field2;
-            xrefEntry.m_gen_ref = field3;
-            break;
-          case 2:
-            xrefEntry.m_type = 2;
-            xrefEntry.m_ofs_idx = field3;
-            xrefEntry.m_gen_ref = field2;
-            break;
-        }
+        // Prevent out-of-bounds read
+        length = 0;
       }
       start++;
     }
@@ -1197,8 +1205,8 @@ wxPdfParser::ResolveObject(wxPdfObject* obj)
     obj = ParseSpecificObject(idx);
     if (obj != NULL)
     {
-    obj->SetCreatedIndirect(true);
-  }
+      obj->SetCreatedIndirect(true);
+    }
   }
   return obj;
 }
@@ -1281,20 +1289,20 @@ wxPdfParser::ParseDirectObject(int k)
     m_objGen = 0;
     if (obj != NULL && obj->GetType() == OBJTYPE_STREAM)
     {
-    wxPdfStream* objStream = (wxPdfStream*) obj;
+      wxPdfStream* objStream = (wxPdfStream*) obj;
       obj = ParseObjectStream(objStream, m_xref[k].m_ofs_idx);
-    if (m_cacheObjects)
-    {
-      if (!isCached)
+      if (m_cacheObjects)
       {
-        (*m_objStmCache)[objIndex] = objStream;
+        if (!isCached)
+        {
+          (*m_objStmCache)[objIndex] = objStream;
+        }
+      }
+      else
+      {
+        delete objStream;
       }
     }
-    else
-    {
-      delete objStream;
-    }
-  }
     else
     {
       // Object not found or not a stream
@@ -1305,10 +1313,10 @@ wxPdfParser::ParseDirectObject(int k)
   if (obj != NULL)
   {
     obj->SetObjNum(m_objNum, m_objGen);
-  if (obj->GetType() == OBJTYPE_STREAM)
-  {
-    GetStreamBytes((wxPdfStream*) obj);
-  }
+    if (obj->GetType() == OBJTYPE_STREAM)
+    {
+      GetStreamBytes((wxPdfStream*) obj);
+    }
   }
   return obj;
 }


### PR DESCRIPTION
Added some pointer, boundary, and integer underflow checks from clang-tidy warnings.

The changes in `pdfparser.cpp` actually aren't as drastic as they look in this web interface, sorry about that. It's actually only 3 new `if` gates around existing code and that code getting indented.