### PR TITLE
Fix PolyPolygon line drawing in image

### DIFF
--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -1089,7 +1089,7 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
               }
               else
               {
-                data += wxString::Format(wxS("%d %d m\n"), (int) px, (int) py);
+                data += wxString::Format(wxS("%d %d l\n"), (int) px, (int) py);
               }
             }
 


### PR DESCRIPTION
move command was being issued for non-last segments instead of line command. Please correct me if I'm wrong, but I think this fix is correct, compared to how `Polygon` works a few lines up.