### PR TITLE
Preserve font style in wxPdfFontExtended to fix intermittent style loss

### DIFF
--- a/include/wx/pdffontextended.h
+++ b/include/wx/pdffontextended.h
@@ -317,6 +317,7 @@ private:
 
   bool                 m_embed;        ///< Flag whether the font should be embedded
   bool                 m_subset;       ///< Flag whether the font should be subsetted
+  int                  m_fontStyle;    ///< Font style flags
   wxPdfFontData*       m_fontData;     ///< Real font data
   const wxPdfEncoding* m_encoding;     ///< Font encoding for Type1 fonts
 

--- a/src/pdffontextended.cpp
+++ b/src/pdffontextended.cpp
@@ -30,13 +30,13 @@
 #include "wx/pdffontdatatype1.h"
 
 wxPdfFontExtended::wxPdfFontExtended()
-  : m_embed(false), m_subset(false),
+  : m_embed(false), m_subset(false), m_fontStyle(wxPDF_FONTSTYLE_REGULAR),
     m_fontData(NULL), m_encoding(NULL)
 {
 }
 
 wxPdfFontExtended::wxPdfFontExtended(const wxPdfFont& font)
-  : m_embed(font.m_embed), m_subset(font.m_subset),
+  : m_embed(font.m_embed), m_subset(font.m_subset), m_fontStyle(font.m_fontStyle),
     m_fontData(font.m_fontData)
 {
   if (m_fontData != NULL)
@@ -47,7 +47,7 @@ wxPdfFontExtended::wxPdfFontExtended(const wxPdfFont& font)
 }
 
 wxPdfFontExtended::wxPdfFontExtended(const wxPdfFontExtended& font)
-  : m_embed(font.m_embed), m_subset(font.m_subset),
+  : m_embed(font.m_embed), m_subset(font.m_subset), m_fontStyle(font.m_fontStyle),
     m_fontData(font.m_fontData)
 {
   if (m_fontData != NULL)
@@ -73,7 +73,7 @@ wxPdfFontExtended::operator=(const wxPdfFontExtended& font)
   wxPdfFontData* const prevFontData = m_fontData;
   m_embed = font.m_embed;
   m_subset = font.m_subset;
-//  m_fontStyle = font.m_fontStyle;
+  m_fontStyle = font.m_fontStyle;
   m_fontData = font.m_fontData;
   if (m_fontData != NULL)
   {
@@ -114,7 +114,7 @@ wxPdfFontExtended::GetName() const
 int
 wxPdfFontExtended::GetStyle() const
 {
-  return (m_fontData != NULL) ? m_fontData->GetStyle() : wxPDF_FONTSTYLE_REGULAR;
+  return m_fontStyle;
 }
 
 int
@@ -376,6 +376,7 @@ wxPdfFontExtended::GetUserFont() const
   wxPdfFont userFont;
   userFont.m_embed = m_embed;
   userFont.m_subset = m_subset;
+  userFont.m_fontStyle = m_fontStyle;
   userFont.m_fontData = m_fontData;
   if (m_fontData != NULL)
   {


### PR DESCRIPTION
I randomly experience bold and italics not getting applied in the output (via `wxPDFDC`). It seems to be happening because the font that I have selected is not explicitly bold, and when `wxPdfFontExtended` -> `wxPdfFont` conversions happen my bold style request gets lost. Storing the style info in a dedicated field instead of relying on it to be in the font data fixes the issue.

Looks like this was an experimental solution at some point (based on a commented out line); it works well for me.

I think the problem is that if I select "Segoe UI Bold" then it's never an issue, but if I select "Segoe UI" and add `wxFONTWEIGHT_BOLD` style then at some point it will get lost. With this change, I am guaranteed to keep my bold style active, regardless of what is in the font data.