### PR TITLE
Fix memset issue

### DIFF
--- a/src/pdfbarcodezint.cpp
+++ b/src/pdfbarcodezint.cpp
@@ -402,7 +402,7 @@ void wxPdfBarcodeZint::SetStructApp(const int count, const int index, const wxSt
 
 void wxPdfBarcodeZint::ClearStructApp()
 {
-  memset(&m_structapp, 0, sizeof(m_structapp));
+  memset(m_structapp, 0, sizeof(zint_structapp));
 }
 
 bool wxPdfBarcodeZint::SetFgColourStr(const wxString& fgStr)


### PR DESCRIPTION
The address of a pointer (`m_structapp`) was getting zeroed out instead of the actual data.