### PR TITLE
Set creator to app name if empty.

### DIFF
--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -679,6 +679,11 @@ wxPdfDocument::PutInfo()
     Out("/Creator ",false);
     OutTextstring(m_creator);
   }
+  else
+  {
+    Out("/Creator ", false);
+    OutTextstring(wxTheApp->GetAppDisplayName());
+  }
   Out("/CreationDate ",false);
   if (m_creationDateSet)
   {


### PR DESCRIPTION
Hello! If creator is empty, then implicitly set it from the application name. This might be presumptuous, so I guess I'll leave it up to you (but it made sense to me). Thanks!