### PR TITLE
Fix GCC warnings

### DIFF
--- a/include/wx/pdffontdescription.h
+++ b/include/wx/pdffontdescription.h
@@ -61,6 +61,12 @@ public:
   */
   wxPdfFontDescription(const wxPdfFontDescription& desc);
 
+  /// Copy assignment operator
+  /**
+  * \param desc The font description to copy
+  */
+  wxPdfFontDescription& operator=(const wxPdfFontDescription& desc);
+
   /// Default destructor
   ~wxPdfFontDescription();
 

--- a/src/pdffontdescription.cpp
+++ b/src/pdffontdescription.cpp
@@ -75,6 +75,34 @@ wxPdfFontDescription::wxPdfFontDescription(const wxPdfFontDescription& desc)
   m_os2usWinDescent    = desc.m_os2usWinDescent;
 }
 
+wxPdfFontDescription&
+wxPdfFontDescription::operator=(const wxPdfFontDescription& desc)
+{
+  if (this != &desc)
+  {
+    m_ascent             = desc.m_ascent;
+    m_descent            = desc.m_descent;
+    m_capHeight          = desc.m_capHeight;
+    m_flags              = desc.m_flags;
+    m_fontBBox           = desc.m_fontBBox;
+    m_italicAngle        = desc.m_italicAngle;
+    m_stemV              = desc.m_stemV;
+    m_missingWidth       = desc.m_missingWidth;
+    m_xHeight            = desc.m_xHeight;
+    m_underlinePosition  = desc.m_underlinePosition;
+    m_underlineThickness = desc.m_underlineThickness;
+    m_hheaAscender       = desc.m_hheaAscender;
+    m_hheaDescender      = desc.m_hheaDescender;
+    m_hheaLineGap        = desc.m_hheaLineGap;
+    m_os2sTypoAscender   = desc.m_os2sTypoAscender;
+    m_os2sTypoDescender  = desc.m_os2sTypoDescender;
+    m_os2sTypoLineGap    = desc.m_os2sTypoLineGap;
+    m_os2usWinAscent     = desc.m_os2usWinAscent;
+    m_os2usWinDescent    = desc.m_os2usWinDescent;
+  }
+  return *this;
+}
+
 wxPdfFontDescription::~wxPdfFontDescription()
 {
 }

--- a/src/pdffontmanager.cpp
+++ b/src/pdffontmanager.cpp
@@ -1207,10 +1207,10 @@ wxPdfFontManagerBase::GetFont(const wxString& fontName, int fontStyle) const
       if (fontData == NULL)
       {
         // If still not found, check if a font was registered directly under this name with the fallback style
-        wxPdfFontNameMap::const_iterator fontIter = m_fontNameMap.find(lcFontName);
-        if (fontIter != m_fontNameMap.end())
+        wxPdfFontNameMap::const_iterator foundFontIter = m_fontNameMap.find(lcFontName);
+        if (foundFontIter != m_fontNameMap.end())
         {
-          wxPdfFontData* candidate = m_fontList[fontIter->second]->GetFontData();
+          wxPdfFontData* candidate = m_fontList[foundFontIter->second]->GetFontData();
           if (candidate->GetStyle() == fallbackStyle)
             fontData = candidate;
         }


### PR DESCRIPTION
Modern C++11 demands explicit `operator=` if copy CTOR is defined.
Also, fix shadow var.