### PR TITLE
Fix various clang and cppcheck warnings

### DIFF
--- a/include/wx/pdfdocdef.h
+++ b/include/wx/pdfdocdef.h
@@ -1517,4 +1517,17 @@ If neither a row nor a cell background colour is specified the background is tra
   #define WXDLLIMPEXP_FWD_PDFDOC WXDLLIMPEXP_PDFDOC
 #endif
 
+// Support for intentional fallthrough in switch statements
+#ifndef wxFALLTHROUGH
+  #if (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+    #define wxFALLTHROUGH [[fallthrough]]
+  #elif defined(__GNUC__) && (__GNUC__ >= 7)
+    #define wxFALLTHROUGH __attribute__ ((fallthrough))
+  #elif defined(__clang__) && __has_attribute(fallthrough)
+    #define wxFALLTHROUGH __attribute__ ((fallthrough))
+  #else
+    #define wxFALLTHROUGH ((void)0)
+  #endif
+#endif
+
 #endif // _PDFDOC_DEF_H_

--- a/makefont/makefont.cpp
+++ b/makefont/makefont.cpp
@@ -1098,6 +1098,13 @@ MakeFont::MakeFontUFM(const wxString& fontFileName,
     cff = (type == wxS("OpenType"));
   }
 
+  wxFileInputStream ufmFile(ufmFileName);
+  if (!ufmFile.Ok())
+  {
+    wxLogMessage(wxS("Error: Unable to read UFM file '") + ufmFileName + wxS("'."));
+    return false;
+  }
+
   wxPdfFontData* ufmFont;
   if (cff)
   {
@@ -1123,13 +1130,6 @@ MakeFont::MakeFontUFM(const wxString& fontFileName,
   bool hasMissingWidth = false;
   int flags = 0;
 
-  wxFileInputStream ufmFile(ufmFileName);
-  if (!ufmFile.Ok())
-  {
-    wxLogMessage(wxS("Error: Unable to read UFM file '") + ufmFileName + wxS("'."));
-    delete ufmFont;
-    return false;
-  }
   wxTextInputStream text(ufmFile);
 
   // Prepare empty CIDToGIDMap

--- a/makefont/makefont.cpp
+++ b/makefont/makefont.cpp
@@ -1519,7 +1519,7 @@ static const wxCmdLineEntryDesc cmdLineDesc[] =
   { wxCMD_LINE_OPTION, "p", "patch",     "Patch file (for AFM only)",                       wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
   { wxCMD_LINE_OPTION, "t", "type",      "Font type (type = otf, ttf or t1, default: ttf)", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
   { wxCMD_LINE_OPTION, "o", "output",    "Path to output directory",                        wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
-  { wxCMD_LINE_NONE }
+  { wxCMD_LINE_NONE, NULL, NULL, NULL, wxCMD_LINE_VAL_NONE, 0 }
 };
 
 bool

--- a/makefont/makefont.cpp
+++ b/makefont/makefont.cpp
@@ -1127,6 +1127,7 @@ MakeFont::MakeFontUFM(const wxString& fontFileName,
   if (!ufmFile.Ok())
   {
     wxLogMessage(wxS("Error: Unable to read UFM file '") + ufmFileName + wxS("'."));
+    delete ufmFont;
     return false;
   }
   wxTextInputStream text(ufmFile);
@@ -1342,6 +1343,7 @@ MakeFont::MakeFontUFM(const wxString& fontFileName,
     {
       wxLogMessage(wxS("Error: Unable to read font file '") + fontFileName + wxS("'."));
       delete [] cc2gn;
+      delete ufmFont;
       return false;
     }
     size_t len = fontFile.GetLength();

--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -157,7 +157,7 @@ static const wxCmdLineEntryDesc cmdLineDesc[] =
   { wxCMD_LINE_OPTION, "f", "fontdir",   "wxPdfDocument font directory",     wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
   { wxCMD_LINE_SWITCH, "t", "testmode",  "Non-interactive testmode",         wxCMD_LINE_VAL_NONE,   wxCMD_LINE_PARAM_OPTIONAL },
   { wxCMD_LINE_SWITCH, "h", "help",      "Display help",                     wxCMD_LINE_VAL_NONE,   wxCMD_LINE_OPTION_HELP },
-  { wxCMD_LINE_NONE }
+  { wxCMD_LINE_NONE, NULL, NULL, NULL, wxCMD_LINE_VAL_NONE, 0 }
 };
 
 

--- a/samples/pdfdc/printing.cpp
+++ b/samples/pdfdc/printing.cpp
@@ -109,7 +109,7 @@ static const wxCmdLineEntryDesc cmdLineDesc[] =
   { wxCMD_LINE_OPTION, "s", "sampledir", "wxPdfDocument samples directory",  wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
   { wxCMD_LINE_OPTION, "f", "fontdir",   "wxPdfDocument font directory",     wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
   { wxCMD_LINE_SWITCH, "h", "help",      "Display help",                     wxCMD_LINE_VAL_NONE,   wxCMD_LINE_OPTION_HELP },
-  { wxCMD_LINE_NONE }
+  { wxCMD_LINE_NONE, NULL, NULL, NULL, wxCMD_LINE_VAL_NONE, 0 }
 };
 
 bool MyApp::OnInit(void)
@@ -321,8 +321,8 @@ EVT_MENU(WXPDFPRINT_HTML_PREVIEW, MyFrame::OnPdfHtmlPreview)
 END_EVENT_TABLE()
 
 // Define my frame constructor
-MyFrame::MyFrame(wxFrame *frame, const wxString& title, const wxPoint& pos, const wxSize& size):
-wxFrame(frame, wxID_ANY, title, pos, size)
+MyFrame::MyFrame(wxFrame *parent, const wxString& title, const wxPoint& pos, const wxSize& size):
+wxFrame(parent, wxID_ANY, title, pos, size)
 {
 #ifdef __WXMAC__
     wxString rscPath = wxStandardPaths::Get().GetResourcesDir() + wxFileName::GetPathSeparator();
@@ -474,10 +474,10 @@ void MyFrame::OnPrintPreview(wxCommandEvent& WXUNUSED(event))
         return;
     }
 
-    wxPreviewFrame *frame = new wxPreviewFrame(preview, this, "Demo Print Preview", wxPoint(100, 100), wxSize(600, 650));
-    frame->Centre(wxBOTH);
-    frame->Initialize();
-    frame->Show();
+    wxPreviewFrame *previewFrame = new wxPreviewFrame(preview, this, "Demo Print Preview", wxPoint(100, 100), wxSize(600, 650));
+    previewFrame->Centre(wxBOTH);
+    previewFrame->Initialize();
+    previewFrame->Show();
 }
 
 void MyFrame::OnPageSetup(wxCommandEvent& WXUNUSED(event))
@@ -873,11 +873,11 @@ void MyFrame::OnPdfRichTextPreview(wxCommandEvent&  WXUNUSED(event) )
       wxPdfPrintPreview *preview = new wxPdfPrintPreview(previewPrintout, printPrintout, &printData);
       if (preview->IsOk())
       {
-        wxPreviewFrame *frame = new wxPreviewFrame(preview, this,
+        wxPreviewFrame *previewFrame = new wxPreviewFrame(preview, this,
                 _("PDF Document RichText Preview"), wxDefaultPosition, wxSize(600,600));
-        frame->Centre(wxBOTH);
-        frame->Initialize();
-        frame->Show(true);
+        previewFrame->Centre(wxBOTH);
+        previewFrame->Initialize();
+        previewFrame->Show(true);
       }
       else
       {
@@ -1160,13 +1160,13 @@ void MyFrame::WriteRichTextBuffer()
       cellAttr.GetTextBoxAttr().GetHeight().SetValue(150, wxTEXT_ATTR_UNITS_PIXELS);
 
       wxRichTextTable* table = r.WriteTable(3, 2, attr, cellAttr);
-      int i, j;
-      for (j = 0; j < table->GetRowCount(); j++)
+      int row, col;
+      for (row = 0; row < table->GetRowCount(); row++)
       {
-          for (i = 0; i < table->GetColumnCount(); i++)
+          for (col = 0; col < table->GetColumnCount(); col++)
           {
-              wxString msg = wxString::Format(wxS("This is cell %d, %d"), (j+1), (i+1));
-              r.SetFocusObject(table->GetCell(j, i));
+              wxString msg = wxString::Format(wxS("This is cell %d, %d"), (row+1), (col+1));
+              r.SetFocusObject(table->GetCell(row, col));
               r.WriteText(msg);
           }
       }
@@ -1265,11 +1265,11 @@ void MyFrame::OnPdfHtmlPreview(wxCommandEvent&  WXUNUSED(event) )
       wxPdfPrintPreview *preview = new wxPdfPrintPreview(previewPrintout, printPrintout, &printData);
       if (preview->IsOk())
       {
-        wxPreviewFrame *frame = new wxPreviewFrame(preview, this,
+        wxPreviewFrame *previewFrame = new wxPreviewFrame(preview, this,
                 _("PDF Document Html Preview"), wxDefaultPosition, wxSize(600,600));
-        frame->Centre(wxBOTH);
-        frame->Initialize();
-        frame->Show(true);
+        previewFrame->Centre(wxBOTH);
+        previewFrame->Initialize();
+        previewFrame->Show(true);
       }
       else
       {
@@ -1289,8 +1289,8 @@ BEGIN_EVENT_TABLE(MyCanvas, wxScrolledWindow)
 EVT_MOUSE_EVENTS(MyCanvas::OnEvent)
 END_EVENT_TABLE()
 
-MyCanvas::MyCanvas(wxFrame *frame, const wxPoint& pos, const wxSize& size, long style):
-    wxScrolledWindow(frame, wxID_ANY, pos, size, style)
+MyCanvas::MyCanvas(wxFrame *parent, const wxPoint& pos, const wxSize& size, long style):
+    wxScrolledWindow(parent, wxID_ANY, pos, size, style)
 {
     SetBackgroundColour(* wxWHITE);
 }
@@ -1477,7 +1477,7 @@ void MyPrintout::DrawPageTwo()
 
     { // GetTextExtent demo:
         wxString words[7] = {"This ", "is ", "GetTextExtent ", "testing ", "string. ", "Enjoy ", "it!"};
-        wxCoord w, h;
+        wxCoord textW, textH;
         wxCoord x = 200, y= 250;
         wxFont fnt(15, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
 
@@ -1487,11 +1487,11 @@ void MyPrintout::DrawPageTwo()
         {
             wxString word = words[i];
             word.Remove( word.Len()-1, 1 );
-            dc->GetTextExtent(word, &w, &h);
-            dc->DrawRectangle(x, y, w, h);
-            dc->GetTextExtent(words[i], &w, &h);
+            dc->GetTextExtent(word, &textW, &textH);
+            dc->DrawRectangle(x, y, textW, textH);
+            dc->GetTextExtent(words[i], &textW, &textH);
             dc->DrawText(words[i], x, y);
-            x += w;
+            x += textW;
         }
 
     }

--- a/showfont/showfont.cpp
+++ b/showfont/showfont.cpp
@@ -528,7 +528,7 @@ static const wxCmdLineEntryDesc cmdLineDesc[] =
   { wxCMD_LINE_OPTION, "i", "include-range", "Show characters in range(s) (s1[-e1][,s2[-e2]...])",       wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL   },
   { wxCMD_LINE_OPTION, "x", "exclude-range", "Don't show characters in range(s) (s1[-e1][,s2[-e2]...])", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL   },
   { wxCMD_LINE_SWITCH, "c", "center",        "Center characters in cells",                               wxCMD_LINE_VAL_NONE,   wxCMD_LINE_PARAM_OPTIONAL   },
-  { wxCMD_LINE_NONE }
+  { wxCMD_LINE_NONE, NULL, NULL, NULL, wxCMD_LINE_VAL_NONE, 0 }
 };
 
 bool

--- a/src/crypto/random.cpp
+++ b/src/crypto/random.cpp
@@ -280,7 +280,7 @@ entropy(void* buf, size_t n)
   if (SecRandomCopyBytes(kSecRandomDefault, n, (uint8_t*) buf) == 0)
     return n;
 #elif defined(__linux__) && defined(SYS_getrandom)
-  if (syscall(SYS_getrandom, buf, n, 0) == n)
+  if (syscall(SYS_getrandom, buf, n, 0) == (long) n)
     return n;
 #elif defined(SYS_getentropy)
   if (syscall(SYS_getentropy, buf, n) == 0)

--- a/src/pdfbarcodezint.cpp
+++ b/src/pdfbarcodezint.cpp
@@ -270,9 +270,12 @@ bool wxPdfBarcodeZint::ResetSymbol()
   {
     m_zintSymbol->output_options |= EMBED_VECTOR_FONT;
   }
-  strcpy(m_zintSymbol->fgcolour, m_fgStr.Left(15).c_str());
-  strcpy(m_zintSymbol->bgcolour, m_bgStr.Left(15).c_str());
-  strcpy(m_zintSymbol->primary, m_primaryMessage.Left(127).c_str());
+  memset(m_zintSymbol->fgcolour, 0, 16);
+  strncpy(m_zintSymbol->fgcolour, m_fgStr.c_str(), 15);
+  memset(m_zintSymbol->bgcolour, 0, 16);
+  strncpy(m_zintSymbol->bgcolour, m_bgStr.c_str(), 15);
+  memset(m_zintSymbol->primary, 0, 128);
+  strncpy(m_zintSymbol->primary, m_primaryMessage.c_str(), 127);
   m_zintSymbol->option_1 = m_option1;
   m_zintSymbol->option_2 = m_option2;
   m_zintSymbol->option_3 = m_option3;

--- a/src/pdffontparsertruetype.cpp
+++ b/src/pdffontparsertruetype.cpp
@@ -995,12 +995,15 @@ wxPdfFontParserTrueType::PrepareFontData(wxPdfFontData* fontData)
     wxPdfCMap::iterator cMapIter;
     int cc;
     wxPdfCMapEntry* cMapEntry;
-    for (cMapIter = cMap->begin(); cMapIter != cMap->end(); cMapIter++)
+    if (cMap != NULL)
     {
-      cc = cMapIter->first;
-      cMapEntry = cMapIter->second;
-      (*widths)[cc] = cMapEntry->m_width;
-      (*glyphs)[cc] = cMapEntry->m_glyph;
+      for (cMapIter = cMap->begin(); cMapIter != cMap->end(); cMapIter++)
+      {
+        cc = cMapIter->first;
+        cMapEntry = cMapIter->second;
+        (*widths)[cc] = cMapEntry->m_width;
+        (*glyphs)[cc] = cMapEntry->m_glyph;
+      }
     }
 
     fontData->SetGlyphWidthMap(widths);

--- a/src/pdffontparsertruetype.cpp
+++ b/src/pdffontparsertruetype.cpp
@@ -1717,7 +1717,9 @@ wxPdfFontParserTrueType::ReadKerning(int unitsPerEm)
     wxPdfKernWidthMap* kwMap = nullptr;
     wxPdfKernWidthMap::iterator kw;
     wxUint32 u1, u2;
-    wxUint32 u1prev = 0;
+    // Initialize u1prev to an invalid value to ensure the first glyph
+    // (even index 0) triggers initialization of kwMap
+    wxUint32 u1prev = wxUINT32_MAX;
 
     m_inFont->SeekI(tableLocation->m_offset+2);
     int nTables = ReadUShort();

--- a/src/pdffontparsertype1.cpp
+++ b/src/pdffontparsertype1.cpp
@@ -2747,7 +2747,10 @@ wxPdfFontParserType1::ConvertMACtoPFB(wxInputStream* macFontStream)
             }
             if (blockType != PFB_BLOCK_END)
             {
-              ReadBinary(*m_inFont, TellI(), blockLen, *currentBlock);
+              if (currentBlock != NULL)
+              {
+                ReadBinary(*m_inFont, TellI(), blockLen, *currentBlock);
+              }
             }
             else
             {

--- a/src/pdffontparsertype1.cpp
+++ b/src/pdffontparsertype1.cpp
@@ -1380,7 +1380,7 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
 {
   bool ok = false;
   wxMemoryOutputStream privateDict;
-  wxMemoryOutputStream* eexecStream = new wxMemoryOutputStream();
+  wxMemoryOutputStream eexecStream;
   stream->SeekI(start);
   if (m_isPFB)
   {
@@ -1395,7 +1395,7 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
       {
         char* buf = new char[length];
         stream->Read(buf, length);
-        eexecStream->Write(buf, length);
+        eexecStream.Write(buf, length);
         delete [] buf;
       }
     }
@@ -1434,12 +1434,12 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
             IsHexDigit(prefix[2]) && IsHexDigit(prefix[3]))
         {
           stream->SeekI(offset);
-          DecodeHex(stream, eexecStream);
+          DecodeHex(stream, &eexecStream);
         }
         else
         {
           stream->SeekI(offset);
-          eexecStream->Write(*stream);
+          eexecStream.Write(*stream);
         }
         ok = true;
       }
@@ -1449,12 +1449,11 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
       }
     }
   }
-  if (ok && eexecStream->GetSize() > 0)
+  if (ok && eexecStream.GetSize() > 0)
   {
     // decrypt the encoded binary private dictionary
-    DecodeEExec(eexecStream, &privateDict, 55665U, 4);
+    DecodeEExec(&eexecStream, &privateDict, 55665U, 4);
     m_privateDict = new wxMemoryInputStream(privateDict);
-    delete eexecStream;
 #if 0
     wxFileOutputStream pfbPrivateDict(wxS("pfbprivdict.dat"));
     wxMemoryInputStream tmp(privateDict);

--- a/src/pdffontparsertype1.cpp
+++ b/src/pdffontparsertype1.cpp
@@ -1391,7 +1391,7 @@ wxPdfFontParserType1::GetPrivateDict(wxInputStream* stream, int start)
     do
     {
       ok = ReadPfbTag(stream, blocktype, length);
-      if (ok && blocktype == PFB_BLOCK_BINARY)
+      if (ok && blocktype == PFB_BLOCK_BINARY && length > 0)
       {
         char* buf = new char[length];
         stream->Read(buf, length);
@@ -2403,6 +2403,10 @@ wxPdfFontParserType1::ParseSubrs(wxInputStream* stream)
 void
 wxPdfFontParserType1::ReadBinary(wxInputStream& inStream, int start, int size, wxOutputStream& outStream)
 {
+  if (size <= 0)
+  {
+    return;
+  }
   char* buffer = new char[size];
   inStream.SeekI(start);
   inStream.Read(buffer, size);

--- a/src/pdffontsubsetcff.cpp
+++ b/src/pdffontsubsetcff.cpp
@@ -966,15 +966,19 @@ wxPdfFontSubsetCff::WriteInteger(int value, int size, wxMemoryOutputStream* buff
     case 4:
       locBuffer[i] = (char)((value >> 24) & 0xff);
       i++;
+      wxFALLTHROUGH;
     case 3:
       locBuffer[i] = (char)((value >> 16) & 0xff);
       i++;
+      wxFALLTHROUGH;
     case 2:
       locBuffer[i] = (char)((value >>  8) & 0xff);
       i++;
+      wxFALLTHROUGH;
     case 1:
       locBuffer[i] = (char)((value      ) & 0xff);
       i++;
+      wxFALLTHROUGH;
     default:
       break;
   }

--- a/src/pdfgraphics.cpp
+++ b/src/pdfgraphics.cpp
@@ -253,6 +253,10 @@ wxPdfFlatPath::wxPdfFlatPath(const wxPdfShape* shape, double flatness, int limit
   m_iterType = 0;
   m_iterPoints = 0;
   m_done = false;
+  m_stackSize = 0;
+  m_srcPosX = 0;
+  m_srcPosY = 0;
+  m_srcSegType = wxPDF_SEG_UNDEFINED;
   m_flatnessSq = flatness * flatness;
   m_recursionLimit = limit;
 

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -1171,7 +1171,7 @@ int
 wxPdfImage::ReadIntBE(wxInputStream* imageStream)
 {
   // Read a 4-byte integer from file (big endian)
-  int i32;
+  int i32 = 0;
   imageStream->Read(&i32, 4);
   return wxINT32_SWAP_ON_LE(i32);
 }
@@ -1180,7 +1180,7 @@ int
 wxPdfImage::ReadIntLE(wxInputStream* imageStream)
 {
   // Read a 4-byte integer from file (little endian)
-  int i32;
+  int i32 = 0;
   imageStream->Read(&i32, 4);
   return wxINT32_SWAP_ON_BE(i32);
 }
@@ -1189,7 +1189,7 @@ unsigned int
 wxPdfImage::ReadUIntBE(wxInputStream* imageStream)
 {
   // Read an unsigned 4-byte integer from file (big endian)
-  unsigned int i32;
+  unsigned int i32 = 0;
   imageStream->Read(&i32, 4);
   return wxUINT32_SWAP_ON_LE(i32);
 }
@@ -1198,7 +1198,7 @@ unsigned int
 wxPdfImage::ReadUIntLE(wxInputStream* imageStream)
 {
   // Read an unsigned 4-byte integer from file (little endian)
-  unsigned int i32;
+  unsigned int i32 = 0;
   imageStream->Read(&i32, 4);
   return wxUINT32_SWAP_ON_BE(i32);
 }
@@ -1207,7 +1207,7 @@ short
 wxPdfImage::ReadShortBE(wxInputStream* imageStream)
 {
   // Read a 2-byte integer from file (big endian)
-  short i16;
+  short i16 = 0;
   imageStream->Read(&i16, 2);
   return wxINT16_SWAP_ON_LE(i16);
 }
@@ -1216,7 +1216,7 @@ short
 wxPdfImage::ReadShortLE(wxInputStream* imageStream)
 {
   // Read a 2-byte integer from file (little endian)
-  short i16;
+  short i16 = 0;
   imageStream->Read(&i16, 2);
   return wxINT16_SWAP_ON_BE(i16);
 }
@@ -1225,7 +1225,7 @@ unsigned short
 wxPdfImage::ReadUShortBE(wxInputStream* imageStream)
 {
   // Read a unsigned 2-byte integer from file (big endian)
-  unsigned short i16;
+  unsigned short i16 = 0;
   imageStream->Read(&i16, 2);
   return wxUINT16_SWAP_ON_LE(i16);
 }
@@ -1234,7 +1234,7 @@ unsigned short
 wxPdfImage::ReadUShortLE(wxInputStream* imageStream)
 {
   // Read a unsigned 2-byte integer from file (little endian)
-  unsigned short i16;
+  unsigned short i16 = 0;
   imageStream->Read(&i16, 2);
   return wxUINT16_SWAP_ON_BE(i16);
 }

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -1002,6 +1002,10 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
       case 0x0325: // Polyline
       case 0x0324: // Polygon
         {
+          if (size <= 3)
+          {
+            break;
+          }
           short* coords = new short[size-3];
           for (i = 0; i < size-3; i++)
           {
@@ -1065,6 +1069,10 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
 
       case 0x0538: // PolyPolygon
         {
+          if (size <= 3)
+          {
+            break;
+          }
           short* coords = new short[size-3];
           for (i = 0; i < size-3; i++)
           {

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -3109,10 +3109,11 @@ wxPdfDocument::OutAsciiTextstring(const wxString& s, bool newline)
 {
   // Format an ASCII text string
   size_t ofs = CalculateStreamOffset();
-  size_t len = s.Length();;
+  size_t len = s.Length();
   size_t lenbuf = CalculateStreamLength(len);
   char* mbstr = new char[lenbuf+1];
-  strcpy(&mbstr[ofs],s.ToAscii());
+  memset(mbstr, 0, lenbuf + 1);
+  memcpy(&mbstr[ofs], s.ToAscii(), len);
 
   if (m_encrypted)
   {

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -900,6 +900,8 @@ wxPdfParser::ParseXRefStream(int ptr, bool setTrailer)
     return false;
   }
   wxPdfObject* object = ParseObject();
+  if (object == NULL)
+    return false;
   wxPdfStream* stm = NULL;
   if (object->GetType() == OBJTYPE_STREAM)
   {
@@ -909,6 +911,11 @@ wxPdfParser::ParseXRefStream(int ptr, bool setTrailer)
       delete object;
       return false;
     }
+  }
+  if (stm == NULL || stm->Get(wxS("Size")) == NULL)
+  {
+    delete object;
+    return false;
   }
   int size = ((wxPdfNumber*) stm->Get(wxS("Size")))->GetInt();
   bool indexAllocated = false;

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -906,7 +906,8 @@ wxPdfParser::ParseXRefStream(int ptr, bool setTrailer)
   if (object->GetType() == OBJTYPE_STREAM)
   {
     stm = (wxPdfStream*) object;
-    if (((wxPdfName*) stm->Get(wxS("Type")))->GetName() != wxS("XRef"))
+    wxPdfName* type = (wxPdfName*) stm->Get(wxS("Type"));
+    if (type == NULL || type->GetName() != wxS("XRef"))
     {
       delete object;
       return false;

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -1539,6 +1539,10 @@ void
 wxPdfParser::GetStreamBytesRaw(wxPdfStream* stream)
 {
   wxPdfNumber* streamLength = (wxPdfNumber*) ResolveObject(stream->Get(wxS("Length")));
+  if (streamLength == NULL)
+  {
+    return;
+  }
   size_t size = streamLength->GetInt();
   m_tokens->Seek(stream->GetOffset());
   wxMemoryOutputStream* memoryBuffer = NULL;
@@ -1645,6 +1649,13 @@ wxPdfTokenizer::GetStartXRef()
   char buffer[1024];
   int idx, found;
   off_t size = GetLength();
+  // Need at least 9 bytes to search for the "startxref" marker
+  if (size < 9)
+  {
+    wxLogError(wxString(wxS("wxPdfTokenizer::GetStartXRef: ")) +
+               wxString(_("PDF startxref not found.")));
+    return 0;
+  }
   if (size > 1024) size = 1024;
   off_t pos = GetLength() - size;
   do

--- a/src/pdfrijndael.cpp
+++ b/src/pdfrijndael.cpp
@@ -987,7 +987,10 @@ static UINT32 rcon[30]=
 
 wxPdfRijndael::wxPdfRijndael()
 {
-   m_state = Invalid;
+  m_state = Invalid;
+  m_mode = ECB;
+  m_direction = Encrypt;
+  m_uRounds = 0;
 }
 
 wxPdfRijndael::~wxPdfRijndael()
@@ -1387,7 +1390,7 @@ void wxPdfRijndael::keySched(UINT8 key[_MAX_KEY_COLUMNS][4])
   // The number of calculations depends on keyBits and blockBits
   int uKeyColumns = m_uRounds - 6;
 
-  UINT8 tempKey[_MAX_KEY_COLUMNS][4];
+  UINT8 tempKey[_MAX_KEY_COLUMNS][4] = { { 0 } };
 
   // Copy the input key to the temporary key matrix
 


### PR DESCRIPTION
Mostly replacing `strcpy`, initializing vars, pointer checks, fixing shadow vars, potential memory leaks, and integer underflows.