### PR TITLE
clang-tidy fixes

### DIFF
--- a/src/pdffontsubsetcff.cpp
+++ b/src/pdffontsubsetcff.cpp
@@ -453,7 +453,7 @@ wxPdfFontSubsetCff::ReadCidFontDict()
     if (ok)
     {
       wxPdfCffDictElement* privateOp = FindDictElement((wxPdfCffDictionary*) m_fdDict[j], PRIVATE_OP);
-      ok = (privateOp == NULL);
+      ok = (privateOp != NULL);
       if (ok)
       {
         SeekI((privateOp->GetArgument())->GetOffset());

--- a/src/pdfgraphics.cpp
+++ b/src/pdfgraphics.cpp
@@ -590,7 +590,7 @@ wxPdfFlatPath::MeasurePathLength()
       case wxPDF_SEG_CLOSE:
         points[0] = moveX;
         points[1] = moveY;
-        // Fall into....
+        wxFALLTHROUGH;
 
       case wxPDF_SEG_LINETO:
         thisX = points[0];
@@ -660,7 +660,7 @@ wxPdfDocument::ShapedText(const wxPdfShape& shape, const wxString& text, wxPdfSh
       {
         points[0] = moveX;
         points[1] = moveY;
-        // Fall into...
+        wxFALLTHROUGH;
       }
 
       case wxPDF_SEG_LINETO:

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -804,7 +804,7 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
   short dashArray[8];
   size_t lenDashArray;
   size_t i;
-  short j, k, px, py;
+  short j = 0, k = 0, px = 0, py = 0;
   GdiObject* obj = NULL;
   while (!imageStream->Eof() && !endRecord)
   {

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -608,6 +608,7 @@ wxPdfImage::ParseJPG(wxInputStream* imageStream)
       case M_EOI:
         isValid = false;
         ready = true;
+        break;
 
       default:
         {

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -2965,6 +2965,7 @@ wxPdfDocument::OutEscape(const char* s, size_t len)
       case '(':
       case ')':
         Out("\\",false);
+        wxFALLTHROUGH;
       default:
         Out(&s[j],1,false);
         break;

--- a/src/pdfparser.cpp
+++ b/src/pdfparser.cpp
@@ -1314,6 +1314,7 @@ wxPdfParser::ParseDirectObject(int k)
     else
     {
       // Object not found or not a stream
+      delete obj;
       obj = NULL;
     }
   }

--- a/src/pdfrijndael.cpp
+++ b/src/pdfrijndael.cpp
@@ -1481,7 +1481,7 @@ void wxPdfRijndael::keyEncToDec()
 
 void wxPdfRijndael::encrypt(const UINT8 a[16], UINT8 b[16])
 {
-  UINT32 r;
+  UINT32 r = 0;
   UINT8 temp[4][4];
 
     *((UINT32*)temp[0]) = *((UINT32*)(a   )) ^ *((UINT32*)m_expandedKey[0][0]);
@@ -1556,8 +1556,8 @@ void wxPdfRijndael::encrypt(const UINT8 a[16], UINT8 b[16])
 
 void wxPdfRijndael::decrypt(const UINT8 a[16], UINT8 b[16])
 {
-  int r;
-  UINT8 temp[4][4];
+  int r = 0;
+  UINT8 temp[4][4] = { { 0 } };
 
     *((UINT32*)temp[0]) = *((UINT32*)(a   )) ^ *((UINT32*)m_expandedKey[m_uRounds][0]);
     *((UINT32*)temp[1]) = *((UINT32*)(a+ 4)) ^ *((UINT32*)m_expandedKey[m_uRounds][1]);


### PR DESCRIPTION
This is one `break` statement that I added to a switch statement whose omission I believe was a bug, that could be confirmed. Same for a reported memory leak that I delete now; I traced it and I believe it is correct to delete this.