### PR TITLE
Suppress int comp warnings, add bounds checks

### DIFF
--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -1014,7 +1014,7 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
           }
           short numpoints = coords[0];
 
-          for (k = numpoints; k > 0; k--)
+          for (k = numpoints; k > 0 && 2*k < (int) (size - 3); k--)
           {
             px = coords[2*k-1];
             py = coords[2*k];
@@ -1083,11 +1083,11 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
 
           short adjustment = numpolygons;
 
-          for (j = 1; j <= numpolygons; j++)
+          for (j = 1; j <= numpolygons && j < (int) (size - 3); j++)
           {
             short numpoints = coords[j];
 
-            for (k = numpoints; k > 0; k--)
+            for (k = numpoints; k > 0 && 2*k + adjustment < (int) (size - 3); k--)
             {
               px = coords[2*k-1 + adjustment];
               py = coords[2*k   + adjustment];

--- a/src/pdfimage.cpp
+++ b/src/pdfimage.cpp
@@ -1014,18 +1014,21 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
           }
           short numpoints = coords[0];
 
-          for (k = numpoints; k > 0 && 2*k < (int) (size - 3); k--)
+          if (2*numpoints < (int) (size - 3))
           {
-            px = coords[2*k-1];
-            py = coords[2*k];
+            for (k = numpoints; k > 0; k--)
+            {
+              px = coords[2*k-1];
+              py = coords[2*k];
 
-            if (k < numpoints)
-            {
-              data += wxString::Format(wxS("%d %d l\n"), (int) px, (int) py);
-            }
-            else
-            {
-              data += wxString::Format(wxS("%d %d m\n"), (int) px, (int) py);
+              if (k < numpoints)
+              {
+                data += wxString::Format(wxS("%d %d l\n"), (int) px, (int) py);
+              }
+              else
+              {
+                data += wxString::Format(wxS("%d %d m\n"), (int) px, (int) py);
+              }
             }
           }
 
@@ -1083,26 +1086,34 @@ wxPdfImage::ParseWMF(wxInputStream* imageStream)
 
           short adjustment = numpolygons;
 
-          for (j = 1; j <= numpolygons && j < (int) (size - 3); j++)
+          if (numpolygons < (int) (size - 3))
           {
-            short numpoints = coords[j];
-
-            for (k = numpoints; k > 0 && 2*k + adjustment < (int) (size - 3); k--)
+            for (j = 1; j <= numpolygons; j++)
             {
-              px = coords[2*k-1 + adjustment];
-              py = coords[2*k   + adjustment];
+              short numpoints = coords[j];
 
-              if (k == numpoints)
+              if (2*numpoints + adjustment >= (int) (size - 3))
               {
-                data += wxString::Format(wxS("%d %d m\n"), (int) px, (int) py);
+                break;
               }
-              else
+
+              for (k = numpoints; k > 0; k--)
               {
-                data += wxString::Format(wxS("%d %d l\n"), (int) px, (int) py);
+                px = coords[2*k-1 + adjustment];
+                py = coords[2*k   + adjustment];
+
+                if (k == numpoints)
+                {
+                  data += wxString::Format(wxS("%d %d m\n"), (int) px, (int) py);
+                }
+                else
+                {
+                  data += wxString::Format(wxS("%d %d l\n"), (int) px, (int) py);
+                }
               }
+
+              adjustment += numpoints * 2;
             }
-
-            adjustment += numpoints * 2;
           }
 
           if (nullPen)

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -2469,14 +2469,14 @@ wxPdfDocument::PutPatterns()
             Out("/FunctionType 3");
             Out("/Domain [0 1]");
             Out("/Functions [ ", false);
-            for (int id = 0; id <= (int) nStops ; ++id)
+            for (size_t id = 0; id <= nStops; ++id)
             {
-              OutAscii(wxString::Format(wxS("%d 0 R "), idFuncShading+id), false);
+              OutAscii(wxString::Format(wxS("%d 0 R "), idFuncShading + (int) id), false);
             }
             Out("]");
 
             Out("/Bounds [ ", false);
-            for (int id = 1; id <= (int) nStops; ++id)
+            for (size_t id = 1; id <= nStops; ++id)
             {
               OutAscii(wxPdfUtility::Double2String(stops.Item(id).GetPosition(), 3), false);
               Out(" ", false);
@@ -2484,7 +2484,7 @@ wxPdfDocument::PutPatterns()
             Out("]");
 
             Out("/Encode [ ", false);
-            for (int id = 0; id <= (int) nStops; ++id)
+            for (size_t id = 0; id <= nStops; ++id)
             {
               Out("0 1 ", false);
             }

--- a/src/pdfkernel.cpp
+++ b/src/pdfkernel.cpp
@@ -2469,14 +2469,14 @@ wxPdfDocument::PutPatterns()
             Out("/FunctionType 3");
             Out("/Domain [0 1]");
             Out("/Functions [ ", false);
-            for (int id = 0; id <= nStops ; ++id)
+            for (int id = 0; id <= (int) nStops ; ++id)
             {
               OutAscii(wxString::Format(wxS("%d 0 R "), idFuncShading+id), false);
             }
             Out("]");
 
             Out("/Bounds [ ", false);
-            for (int id = 1; id <= nStops; ++id)
+            for (int id = 1; id <= (int) nStops; ++id)
             {
               OutAscii(wxPdfUtility::Double2String(stops.Item(id).GetPosition(), 3), false);
               Out(" ", false);
@@ -2484,7 +2484,7 @@ wxPdfDocument::PutPatterns()
             Out("]");
 
             Out("/Encode [ ", false);
-            for (int id = 0; id <= nStops; ++id)
+            for (int id = 0; id <= (int) nStops; ++id)
             {
               Out("0 1 ", false);
             }


### PR DESCRIPTION
I'm hoping this takes care of the last GCC and clang-analyzer warnings.