### PR TITLE
Add wxListCtrl support to document and DC classes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,7 @@ lib@WXPDFDOC_LIBNAME@_la_SOURCES = \
     src/pdfimage.cpp \
     src/pdfkernel.cpp \
     src/pdflayer.cpp \
+    src/pdflistctrl.cpp \
     src/pdfobjects.cpp \
     src/pdfocg.cpp \
     src/pdfparser.cpp \

--- a/include/wx/pdfdc.h
+++ b/include/wx/pdfdc.h
@@ -12,10 +12,15 @@
 #ifndef _PDF_DC_H_
 #define _PDF_DC_H_
 
+#include <wx/defs.h>
 #include <wx/cmndata.h>
 #include <wx/dc.h>
 
 #include <stack>
+
+#if wxUSE_LISTCTRL
+class wxListCtrl;
+#endif
 
 #include "wx/pdfdocument.h"
 #include "wx/pdffont.h"
@@ -135,6 +140,18 @@ public:
   * \see SetMapModeStyle()
   */
   wxPdfMapModeStyle GetMapModeStyle() const;
+
+#if wxUSE_LISTCTRL
+  /// Draws a list control's content at the given position
+  /**
+  * \param list Pointer to the list control
+  * \param x Abscissa of the top left corner
+  * \param y Ordinate of the top left corner
+  * \param options Export options
+  */
+  void DrawList(wxListCtrl* list, wxCoord x, wxCoord y,
+                const wxPdfListCtrlOptions& options = wxPdfListCtrlOptions());
+#endif
 
 private:
   wxDECLARE_DYNAMIC_CLASS(wxPdfDC);

--- a/include/wx/pdfdocument.h
+++ b/include/wx/pdfdocument.h
@@ -13,6 +13,10 @@
 #ifndef _PDF_DOCUMENT_H_
 #define _PDF_DOCUMENT_H_
 
+#if wxUSE_LISTCTRL
+class wxListCtrl;
+#endif
+
 // wxWidgets headers
 #include <wx/dynarray.h>
 #include <wx/graphics.h>
@@ -32,6 +36,10 @@
 #include "wx/pdflinks.h"
 #include "wx/pdfproperties.h"
 #include "wx/pdfdoc_version.h"
+
+#if wxUSE_LISTCTRL
+#include "wx/pdflistctrl.h"
+#endif
 
 #define wxPDF_PRODUCER       wxS(PDFDOC_VERSION_STRING)
 
@@ -2969,6 +2977,15 @@ public:
   * \see \ref writexml
   */
   virtual void WriteXml(const wxString& str);
+
+#if wxUSE_LISTCTRL
+  /// Adds a list control's content to the document
+  /**
+  * \param list Pointer to the list control
+  * \param options Export options
+  */
+  virtual void AddList(wxListCtrl* list, const wxPdfListCtrlOptions& options = wxPdfListCtrlOptions());
+#endif
 
   /// Adds a check box field at the current position
   /**

--- a/include/wx/pdflistctrl.h
+++ b/include/wx/pdflistctrl.h
@@ -19,6 +19,7 @@
 // wxPdfDocument headers
 #include "wx/pdfdocdef.h"
 #include "wx/pdfcolour.h"
+#include "wx/pdffont.h"
 
 class wxListCtrl;
 
@@ -88,6 +89,30 @@ public:
   * \return The body font
   */
   wxFont GetBodyFont() const { return m_bodyFont; }
+
+  /// Set the PDF font for the column headers (takes precedence over SetHeaderFont())
+  /**
+  * \param font The wxPdfFont to use for headers
+  */
+  void SetHeaderPdfFont(const wxPdfFont& font) { m_headerPdfFont = font; }
+
+  /// Get the PDF font for the column headers
+  /**
+  * \return The header PDF font
+  */
+  wxPdfFont GetHeaderPdfFont() const { return m_headerPdfFont; }
+
+  /// Set the PDF font for the list items (takes precedence over SetBodyFont())
+  /**
+  * \param font The wxPdfFont to use for items
+  */
+  void SetBodyPdfFont(const wxPdfFont& font) { m_bodyPdfFont = font; }
+
+  /// Get the PDF font for the list items
+  /**
+  * \return The body PDF font
+  */
+  wxPdfFont GetBodyPdfFont() const { return m_bodyPdfFont; }
 
   /// Set the background colour for the column headers
   /**
@@ -207,6 +232,8 @@ public:
 private:
   wxFont      m_headerFont;
   wxFont      m_bodyFont;
+  wxPdfFont   m_headerPdfFont;
+  wxPdfFont   m_bodyPdfFont;
   wxPdfColour m_headerBackgroundColour;
   wxPdfColour m_headerTextColour;
   wxPdfColour m_alternateRowBackgroundColour;

--- a/include/wx/pdflistctrl.h
+++ b/include/wx/pdflistctrl.h
@@ -29,7 +29,36 @@ enum wxPdfListCtrlStyle
     wxPDF_LISTCTRL_STYLE_SIMPLE  ///< Horizontal rules only — no vertical lines or cell fills (LaTeX \e booktabs style)
 };
 
-/// Class representing options for wxListCtrl export.
+/// Options that control how a wxListCtrl is rendered into a PDF document.
+/**
+ * Pass an instance to wxPdfDocument::AddList() or wxPdfDC::DrawList() to
+ * configure colours, fonts, borders, and layout behaviour.
+ *
+ * \par Example
+ * \code
+ * // Standard grid export
+ * wxPdfDocument doc;
+ * doc.AddPage();
+ *
+ * wxPdfListCtrlOptions options;
+ * options.SetHeaderBackgroundColour(wxPdfColour(220, 220, 255));
+ * options.SetAlternateRowBackgroundColour(wxPdfColour(245, 245, 245));
+ * doc.AddList(myListCtrl, options);
+ * doc.SaveAsFile("grid.pdf");
+ *
+ * // LaTeX booktabs-style export stretched to page width
+ * wxPdfDocument doc2;
+ * doc2.AddPage();
+ *
+ * wxPdfListCtrlOptions simple;
+ * simple.SetStyle(wxPDF_LISTCTRL_STYLE_SIMPLE);
+ * simple.SetFitToPage(true);
+ * doc2.AddList(myListCtrl, simple);
+ * doc2.SaveAsFile("simple.pdf");
+ * \endcode
+ *
+ * \see wxPdfDocument::AddList(), wxPdfDC::DrawList()
+ */
 class WXDLLIMPEXP_PDFDOC wxPdfListCtrlOptions
 {
 public:

--- a/include/wx/pdflistctrl.h
+++ b/include/wx/pdflistctrl.h
@@ -137,6 +137,22 @@ public:
   */
   bool GetShowContinued() const { return m_showContinued; }
 
+  /// Set whether to stretch the table to the full printable page width.
+  /**
+  * When enabled, all columns are scaled proportionally so that the table
+  * fills the available width between the left and right margins, analogous
+  * to LaTeX's \c tabularx or \c tabular* with \c \\linewidth. Multi-column
+  * layout is disabled when this option is active.
+  * \param fit true to stretch to full page width
+  */
+  void SetFitToPage(bool fit) { m_fitToPage = fit; }
+
+  /// Check whether the table is stretched to the full printable page width.
+  /**
+  * \return true if full-page-width mode is active
+  */
+  bool GetFitToPage() const { return m_fitToPage; }
+
 private:
   wxFont      m_headerFont;
   wxFont      m_bodyFont;
@@ -147,6 +163,7 @@ private:
   bool        m_drawRowBorders;
   bool        m_drawColumnBorders;
   bool        m_showContinued;
+  bool        m_fitToPage;
 };
 
 #endif

--- a/include/wx/pdflistctrl.h
+++ b/include/wx/pdflistctrl.h
@@ -22,6 +22,13 @@
 
 class wxListCtrl;
 
+/// Table rendering style for wxListCtrl export.
+enum wxPdfListCtrlStyle
+{
+    wxPDF_LISTCTRL_STYLE_GRID,   ///< Full grid with borders and optional cell fills (default)
+    wxPDF_LISTCTRL_STYLE_SIMPLE  ///< Horizontal rules only — no vertical lines or cell fills (LaTeX \e booktabs style)
+};
+
 /// Class representing options for wxListCtrl export.
 class WXDLLIMPEXP_PDFDOC wxPdfListCtrlOptions
 {
@@ -153,6 +160,21 @@ public:
   */
   bool GetFitToPage() const { return m_fitToPage; }
 
+  /// Set the table rendering style.
+  /**
+  * \c wxPDF_LISTCTRL_STYLE_GRID (default) draws full cell borders and honours fill colours.
+  * \c wxPDF_LISTCTRL_STYLE_SIMPLE renders only a top rule, a rule below the header, and a
+  * bottom rule with no vertical lines or cell fills, analogous to the LaTeX \c booktabs package.
+  * \param style The rendering style
+  */
+  void SetStyle(wxPdfListCtrlStyle style) { m_style = style; }
+
+  /// Get the table rendering style.
+  /**
+  * \return The current rendering style
+  */
+  wxPdfListCtrlStyle GetStyle() const { return m_style; }
+
 private:
   wxFont      m_headerFont;
   wxFont      m_bodyFont;
@@ -160,10 +182,11 @@ private:
   wxPdfColour m_headerTextColour;
   wxPdfColour m_alternateRowBackgroundColour;
   wxPdfColour m_borderColour;
-  bool        m_drawRowBorders;
-  bool        m_drawColumnBorders;
-  bool        m_showContinued;
-  bool        m_fitToPage;
+  bool                m_drawRowBorders;
+  bool                m_drawColumnBorders;
+  bool                m_showContinued;
+  bool                m_fitToPage;
+  wxPdfListCtrlStyle  m_style;
 };
 
 #endif

--- a/include/wx/pdflistctrl.h
+++ b/include/wx/pdflistctrl.h
@@ -1,0 +1,152 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        pdflistctrl.h
+// Purpose:     
+// Author:      Blake Madden
+// Created:     2026-06-10
+// Copyright:   (c) Blake Madden
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+/// \file pdflistctrl.h Interface of the wxPdfListCtrlOptions class
+
+#ifndef _PDF_LISTCTRL_H_
+#define _PDF_LISTCTRL_H_
+
+// wxWidgets headers
+#include <wx/defs.h>
+#include <wx/font.h>
+
+// wxPdfDocument headers
+#include "wx/pdfdocdef.h"
+#include "wx/pdfcolour.h"
+
+class wxListCtrl;
+
+/// Class representing options for wxListCtrl export.
+class WXDLLIMPEXP_PDFDOC wxPdfListCtrlOptions
+{
+public:
+  /// Default constructor
+  wxPdfListCtrlOptions();
+
+  /// Set the font for the column headers
+  /**
+  * \param font The font to use for headers
+  */
+  void SetHeaderFont(const wxFont& font) { m_headerFont = font; }
+
+  /// Get the font for the column headers
+  /**
+  * \return The header font
+  */
+  wxFont GetHeaderFont() const { return m_headerFont; }
+
+  /// Set the font for the list items
+  /**
+  * \param font The font to use for items
+  */
+  void SetBodyFont(const wxFont& font) { m_bodyFont = font; }
+
+  /// Get the font for the list items
+  /**
+  * \return The body font
+  */
+  wxFont GetBodyFont() const { return m_bodyFont; }
+
+  /// Set the background colour for the column headers
+  /**
+  * \param colour The background colour
+  */
+  void SetHeaderBackgroundColour(const wxPdfColour& colour) { m_headerBackgroundColour = colour; }
+
+  /// Get the background colour for the column headers
+  /**
+  * \return The header background colour
+  */
+  wxPdfColour GetHeaderBackgroundColour() const { return m_headerBackgroundColour; }
+
+  /// Set the text colour for the column headers
+  /**
+  * \param colour The text colour
+  */
+  void SetHeaderTextColour(const wxPdfColour& colour) { m_headerTextColour = colour; }
+
+  /// Get the text colour for the column headers
+  /**
+  * \return The header text colour
+  */
+  wxPdfColour GetHeaderTextColour() const { return m_headerTextColour; }
+
+  /// Set the background colour for alternate rows
+  /**
+  * \param colour The background colour for even rows
+  */
+  void SetAlternateRowBackgroundColour(const wxPdfColour& colour) { m_alternateRowBackgroundColour = colour; }
+
+  /// Get the background colour for alternate rows
+  /**
+  * \return The alternate row background colour
+  */
+  wxPdfColour GetAlternateRowBackgroundColour() const { return m_alternateRowBackgroundColour; }
+
+  /// Set the colour for borders
+  /**
+  * \param colour The border colour
+  */
+  void SetBorderColour(const wxPdfColour& colour) { m_borderColour = colour; }
+
+  /// Get the colour for borders
+  /**
+  * \return The border colour
+  */
+  wxPdfColour GetBorderColour() const { return m_borderColour; }
+
+  /// Set whether to draw horizontal borders between rows
+  /**
+  * \param draw true to draw row borders
+  */
+  void SetDrawRowBorders(bool draw) { m_drawRowBorders = draw; }
+
+  /// Check whether to draw horizontal borders between rows
+  /**
+  * \return true if row borders should be drawn
+  */
+  bool GetDrawRowBorders() const { return m_drawRowBorders; }
+
+  /// Set whether to draw vertical borders between columns
+  /**
+  * \param draw true to draw column borders
+  */
+  void SetDrawColumnBorders(bool draw) { m_drawColumnBorders = draw; }
+
+  /// Check whether to draw vertical borders between columns
+  /**
+  * \return true if column borders should be drawn
+  */
+  bool GetDrawColumnBorders() const { return m_drawColumnBorders; }
+
+  /// Set whether to show "Continued on next page" and "(continued)" labels
+  /**
+  * \param show true to show the labels
+  */
+  void SetShowContinued(bool show) { m_showContinued = show; }
+
+  /// Check whether to show "Continued on next page" and "(continued)" labels
+  /**
+  * \return true if labels should be shown
+  */
+  bool GetShowContinued() const { return m_showContinued; }
+
+private:
+  wxFont      m_headerFont;
+  wxFont      m_bodyFont;
+  wxPdfColour m_headerBackgroundColour;
+  wxPdfColour m_headerTextColour;
+  wxPdfColour m_alternateRowBackgroundColour;
+  wxPdfColour m_borderColour;
+  bool        m_drawRowBorders;
+  bool        m_drawColumnBorders;
+  bool        m_showContinued;
+};
+
+#endif

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ on the FPDF web site are incorporated into wxPdfDocument.
 - **Document Protection**: Support for document encryption (including AES-256) and permission management.
 - **Templates & Layers**: Import pages from existing PDF documents as templates and organize content with layers (Optional Content Groups).
 - **Markup & Tables**: Use a simple XML markup language for styled text and complex tables with multi-page support.
+- **wxListCtrl Export**: Export any `wxListCtrl` directly to PDF via `wxPdfDocument::AddList()` or `wxPdfDC::DrawList()`. Supports column headers repeated across pages, alternating row colours, per-item text/background colours, full-page-width layout, and a LaTeX *booktabs*-style rendering with horizontal rules only.
 - **Integration**: Includes `wxPdfDC` and `wxPdfGraphicsContext`, providing seamless integration with the wxWidgets `wxDC` and `wxGraphicsContext` APIs and the printing framework.
 - **Standards**: Support for PDF/A-1B conformance.
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -195,3 +195,24 @@ set_target_properties(pdfgc PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     "${WXPDFDOC_ROOT}/samples/pdfgc"
     VS_DEBUGGER_WORKING_DIRECTORY           "${WXPDFDOC_ROOT}/samples/pdfgc"
 )
+
+# ---------------------------------------------------------------------------
+# listctrl sample executable (wxListCtrl export demo)
+# ---------------------------------------------------------------------------
+file(GLOB LISTCTRL_SRCS CONFIGURE_DEPENDS ${WXPDFDOC_ROOT}/samples/listctrl/*.cpp)
+
+add_executable(listctrl WIN32 ${LISTCTRL_SRCS})
+if(WIN32)
+    target_sources(listctrl PRIVATE ${WXPDFDOC_ROOT}/samples/listctrl/listctrlsample.rc)
+endif()
+target_include_directories(listctrl PRIVATE ${WXPDFDOC_ROOT}/samples/listctrl)
+target_link_libraries(listctrl PRIVATE wxpdfdoc)
+
+set_target_properties(listctrl PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY                "${WXPDFDOC_ROOT}/samples/listctrl"
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG          "${WXPDFDOC_ROOT}/samples/listctrl"
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE        "${WXPDFDOC_ROOT}/samples/listctrl"
+    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${WXPDFDOC_ROOT}/samples/listctrl"
+    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     "${WXPDFDOC_ROOT}/samples/listctrl"
+    VS_DEBUGGER_WORKING_DIRECTORY           "${WXPDFDOC_ROOT}/samples/listctrl"
+)

--- a/samples/listctrl/listctrlsample.cpp
+++ b/samples/listctrl/listctrlsample.cpp
@@ -107,11 +107,9 @@ void MyFrame::OnExportDirect(wxCommandEvent& WXUNUSED(event))
   doc.AddPage();
   
   wxPdfListCtrlOptions options;
-  options.SetHeaderBackgroundColour(wxPdfColour(230, 200, 180));
-  options.SetHeaderTextColour(*wxBLACK);
   options.SetAlternateRowBackgroundColour(wxPdfColour(240, 240, 240));
   options.SetBorderColour(wxPdfColour(200, 200, 200));
-  
+
   doc.AddList(m_list, options);
   doc.SaveAsFile(saveFileDialog.GetPath());
 }
@@ -135,10 +133,8 @@ void MyFrame::OnExportDC(wxCommandEvent& WXUNUSED(event))
   dc.DrawText("Exported List via wxPdfDC", 10, 10);
   
   wxPdfListCtrlOptions options;
-  options.SetHeaderBackgroundColour(wxPdfColour(230, 200, 180));
-  options.SetHeaderTextColour(*wxBLACK);
   options.SetBorderColour(wxPdfColour(200, 200, 200));
-  
+
   dc.DrawList(m_list, 10, 30, options);
   
   dc.EndPage();
@@ -176,8 +172,6 @@ void MyFrame::OnExportFullWidth(wxCommandEvent& WXUNUSED(event))
   doc.AddPage();
 
   wxPdfListCtrlOptions options;
-  options.SetHeaderBackgroundColour(wxPdfColour(230, 200, 180));
-  options.SetHeaderTextColour(*wxBLACK);
   options.SetAlternateRowBackgroundColour(wxPdfColour(240, 240, 240));
   options.SetBorderColour(wxPdfColour(200, 200, 200));
   options.SetFitToPage(true);

--- a/samples/listctrl/listctrlsample.cpp
+++ b/samples/listctrl/listctrlsample.cpp
@@ -22,6 +22,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
   EVT_MENU(ID_EXPORT_DIRECT,     MyFrame::OnExportDirect)
   EVT_MENU(ID_EXPORT_DC,         MyFrame::OnExportDC)
   EVT_MENU(ID_EXPORT_FULL_WIDTH, MyFrame::OnExportFullWidth)
+  EVT_MENU(ID_EXPORT_SIMPLE,     MyFrame::OnExportSimple)
   EVT_MENU(wxID_EXIT,            MyFrame::OnExit)
 wxEND_EVENT_TABLE()
 
@@ -31,7 +32,8 @@ MyFrame::MyFrame(const wxString& title)
   wxMenu* menuFile = new wxMenu;
   menuFile->Append(ID_EXPORT_DIRECT,     "&Export to PDF (Direct)\tCtrl-E",     "Export using wxPdfDocument::AddList");
   menuFile->Append(ID_EXPORT_DC,         "Export to PDF (via &DC)\tCtrl-D",     "Export using wxPdfDC::DrawList");
-  menuFile->Append(ID_EXPORT_FULL_WIDTH, "Export to PDF (&Full Width)\tCtrl-F", "Export with columns stretched to page width");
+  menuFile->Append(ID_EXPORT_FULL_WIDTH, "Export to PDF (&Full Width)\tCtrl-F",  "Export with columns stretched to page width");
+  menuFile->Append(ID_EXPORT_SIMPLE,     "Export to PDF (&Simple/LaTeX)\tCtrl-L", "Export with LaTeX booktabs-style rules only");
   menuFile->AppendSeparator();
   menuFile->Append(wxID_EXIT);
 
@@ -139,6 +141,25 @@ void MyFrame::OnExportDC(wxCommandEvent& WXUNUSED(event))
   
   dc.EndPage();
   dc.EndDoc();
+}
+
+void MyFrame::OnExportSimple(wxCommandEvent& WXUNUSED(event))
+{
+  wxFileDialog saveFileDialog(this, _("Save PDF file"), "", "list_simple.pdf",
+    "PDF files (*.pdf)|*.pdf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+  if (saveFileDialog.ShowModal() == wxID_CANCEL)
+    return;
+
+  wxPdfDocument doc;
+  doc.AddPage();
+
+  wxPdfListCtrlOptions options;
+  options.SetStyle(wxPDF_LISTCTRL_STYLE_SIMPLE);
+  options.SetFitToPage(true);
+
+  doc.AddList(m_list, options);
+  doc.SaveAsFile(saveFileDialog.GetPath());
 }
 
 void MyFrame::OnExportFullWidth(wxCommandEvent& WXUNUSED(event))

--- a/samples/listctrl/listctrlsample.cpp
+++ b/samples/listctrl/listctrlsample.cpp
@@ -19,17 +19,19 @@
 #include "listctrlsample.h"
 
 wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
-  EVT_MENU(ID_EXPORT_DIRECT, MyFrame::OnExportDirect)
-  EVT_MENU(ID_EXPORT_DC, MyFrame::OnExportDC)
-  EVT_MENU(wxID_EXIT, MyFrame::OnExit)
+  EVT_MENU(ID_EXPORT_DIRECT,     MyFrame::OnExportDirect)
+  EVT_MENU(ID_EXPORT_DC,         MyFrame::OnExportDC)
+  EVT_MENU(ID_EXPORT_FULL_WIDTH, MyFrame::OnExportFullWidth)
+  EVT_MENU(wxID_EXIT,            MyFrame::OnExit)
 wxEND_EVENT_TABLE()
 
 MyFrame::MyFrame(const wxString& title)
   : wxFrame(NULL, wxID_ANY, title, wxDefaultPosition, wxSize(800, 600))
 {
   wxMenu* menuFile = new wxMenu;
-  menuFile->Append(ID_EXPORT_DIRECT, "&Export to PDF (Direct)\tCtrl-E", "Export using wxPdfDocument::AddList");
-  menuFile->Append(ID_EXPORT_DC, "Export to PDF (via &DC)\tCtrl-D", "Export using wxPdfDC::DrawList");
+  menuFile->Append(ID_EXPORT_DIRECT,     "&Export to PDF (Direct)\tCtrl-E",     "Export using wxPdfDocument::AddList");
+  menuFile->Append(ID_EXPORT_DC,         "Export to PDF (via &DC)\tCtrl-D",     "Export using wxPdfDC::DrawList");
+  menuFile->Append(ID_EXPORT_FULL_WIDTH, "Export to PDF (&Full Width)\tCtrl-F", "Export with columns stretched to page width");
   menuFile->AppendSeparator();
   menuFile->Append(wxID_EXIT);
 
@@ -137,6 +139,28 @@ void MyFrame::OnExportDC(wxCommandEvent& WXUNUSED(event))
   
   dc.EndPage();
   dc.EndDoc();
+}
+
+void MyFrame::OnExportFullWidth(wxCommandEvent& WXUNUSED(event))
+{
+  wxFileDialog saveFileDialog(this, _("Save PDF file"), "", "list_fullwidth.pdf",
+    "PDF files (*.pdf)|*.pdf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+  if (saveFileDialog.ShowModal() == wxID_CANCEL)
+    return;
+
+  wxPdfDocument doc;
+  doc.AddPage();
+
+  wxPdfListCtrlOptions options;
+  options.SetHeaderBackgroundColour(wxPdfColour(230, 200, 180));
+  options.SetHeaderTextColour(*wxBLACK);
+  options.SetAlternateRowBackgroundColour(wxPdfColour(240, 240, 240));
+  options.SetBorderColour(wxPdfColour(200, 200, 200));
+  options.SetFitToPage(true);
+
+  doc.AddList(m_list, options);
+  doc.SaveAsFile(saveFileDialog.GetPath());
 }
 
 void MyFrame::OnExit(wxCommandEvent& WXUNUSED(event))

--- a/samples/listctrl/listctrlsample.cpp
+++ b/samples/listctrl/listctrlsample.cpp
@@ -23,6 +23,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
   EVT_MENU(ID_EXPORT_DC,         MyFrame::OnExportDC)
   EVT_MENU(ID_EXPORT_FULL_WIDTH, MyFrame::OnExportFullWidth)
   EVT_MENU(ID_EXPORT_SIMPLE,     MyFrame::OnExportSimple)
+  EVT_MENU(ID_EXPORT_FINANCIAL,  MyFrame::OnExportFinancial)
   EVT_MENU(wxID_EXIT,            MyFrame::OnExit)
 wxEND_EVENT_TABLE()
 
@@ -33,7 +34,8 @@ MyFrame::MyFrame(const wxString& title)
   menuFile->Append(ID_EXPORT_DIRECT,     "&Export to PDF (Direct)\tCtrl-E",     "Export using wxPdfDocument::AddList");
   menuFile->Append(ID_EXPORT_DC,         "Export to PDF (via &DC)\tCtrl-D",     "Export using wxPdfDC::DrawList");
   menuFile->Append(ID_EXPORT_FULL_WIDTH, "Export to PDF (&Full Width)\tCtrl-F",  "Export with columns stretched to page width");
-  menuFile->Append(ID_EXPORT_SIMPLE,     "Export to PDF (&Simple/LaTeX)\tCtrl-L", "Export with LaTeX booktabs-style rules only");
+  menuFile->Append(ID_EXPORT_SIMPLE,     "Export to PDF (&Simple/LaTeX)\tCtrl-L",    "Export with LaTeX booktabs-style rules only");
+  menuFile->Append(ID_EXPORT_FINANCIAL,  "Export Financial Data (Lan&dscape)\tCtrl-G", "Export sample ledger with long note cells");
   menuFile->AppendSeparator();
   menuFile->Append(wxID_EXIT);
 
@@ -182,6 +184,106 @@ void MyFrame::OnExportFullWidth(wxCommandEvent& WXUNUSED(event))
 
   doc.AddList(m_list, options);
   doc.SaveAsFile(saveFileDialog.GetPath());
+}
+
+void MyFrame::OnExportFinancial(wxCommandEvent& WXUNUSED(event))
+{
+  wxFileDialog saveFileDialog(this, _("Save PDF file"), "", "list_financial.pdf",
+    "PDF files (*.pdf)|*.pdf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (saveFileDialog.ShowModal() == wxID_CANCEL)
+    return;
+
+  wxListCtrl* fin = new wxListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                                   wxLC_REPORT);
+  fin->Hide();
+
+  fin->InsertColumn(0, "Date",        wxLIST_FORMAT_LEFT,   80);
+  fin->InsertColumn(1, "Ref #",       wxLIST_FORMAT_LEFT,   70);
+  fin->InsertColumn(2, "Account",     wxLIST_FORMAT_LEFT,  130);
+  fin->InsertColumn(3, "Description", wxLIST_FORMAT_LEFT,  160);
+  fin->InsertColumn(4, "Debit ($)",   wxLIST_FORMAT_RIGHT,  80);
+  fin->InsertColumn(5, "Credit ($)",  wxLIST_FORMAT_RIGHT,  80);
+  fin->InsertColumn(6, "Balance ($)", wxLIST_FORMAT_RIGHT,  90);
+  fin->InsertColumn(7, "Notes",       wxLIST_FORMAT_LEFT,  300);
+
+  struct FinRow
+  {
+    const char* date;
+    const char* ref;
+    const char* account;
+    const char* description;
+    const char* debit;
+    const char* credit;
+    const char* balance;
+    const char* notes;
+  };
+
+  static const FinRow rows[] =
+  {
+    { "2026-01-03", "REF-0001", "Cash - Operating",  "January office rent",
+      "4,500.00",  "",          "95,500.00",
+      "Monthly lease payment to the building landlord for the primary office space at Suite 400. "
+      "Annual term ending December 2027 with a 3% escalation clause at renewal." },
+    { "2026-01-05", "REF-0002", "Accounts Rec.",     "Invoice #1042 - Client A",
+      "",          "12,750.00", "108,250.00",
+      "Full settlement of invoice #1042 for software consulting services delivered in Q4 2025. "
+      "Payment received 15 days before the net-30 due date; no early-payment discount applied." },
+    { "2026-01-08", "REF-0003", "Payroll Expense",   "Bi-weekly payroll",
+      "18,320.50", "",          "89,929.50",
+      "Regular bi-weekly payroll for 12 salaried employees and 3 hourly contractors. "
+      "Includes employer FICA of $1,402.32 and group health insurance premiums of $2,160.00." },
+    { "2026-01-10", "REF-0004", "Equipment",         "Laptops - IT dept.",
+      "3,280.00",  "",          "86,649.50",
+      "Purchase of 2 laptops for new engineering hires per capital expenditure request CE-2026-004, "
+      "approved by CFO on 2025-12-18. Depreciation schedule: 3 years straight-line." },
+    { "2026-01-12", "REF-0005", "Accounts Rec.",     "Invoice #1038 - Client B",
+      "",          "8,400.00",  "95,049.50",
+      "Partial payment of 70% on invoice #1038. Remaining balance of $3,600.00 due 2026-02-01 "
+      "per amended payment plan agreed with the client on 2025-12-22." },
+    { "2026-01-15", "REF-0006", "Utilities",         "Monthly utilities - Q1",
+      "1,240.75",  "",          "93,808.75",
+      "Combined electric, gas, and water charges for the main facility. Electricity usage up 8% "
+      "vs. prior month due to HVAC load from a cold snap; flagged for facilities review." },
+    { "2026-01-19", "REF-0007", "Professional Svcs", "Legal retainer - January",
+      "2,500.00",  "",          "91,308.75",
+      "Monthly retainer to outside legal counsel for contract review and IP advisory services. "
+      "Covers up to 10 billable hours; overages billed separately at $350 per hour." },
+    { "2026-01-22", "REF-0008", "Cash - Operating",  "Vendor deposit - SaaS provider",
+      "5,000.00",  "",          "86,308.75",
+      "Advance deposit for a 12-month SaaS infrastructure contract signed 2026-01-20. "
+      "Remaining balance of $55,000.00 due 30 days after the agreed go-live milestone." },
+    { "2026-01-26", "REF-0009", "Revenue",           "Subscription renewals - Jan",
+      "",          "24,600.00", "110,908.75",
+      "Aggregate monthly renewals from 82 active enterprise accounts, including 3 new accounts "
+      "onboarded in January. Churn rate for the period was 1.2%; flagged for retention review." },
+    { "2026-01-31", "REF-0010", "Cash - Operating",  "Bank service fees - January",
+      "87.50",     "",          "110,821.25",
+      "Monthly account maintenance and wire transfer charges; fee schedule unchanged from 2025. "
+      "Under review as part of the Q1 banking relationship assessment initiated by the CFO." },
+  };
+
+  for (const auto& r : rows)
+  {
+    long idx = fin->InsertItem(fin->GetItemCount(), r.date);
+    fin->SetItem(idx, 1, r.ref);
+    fin->SetItem(idx, 2, r.account);
+    fin->SetItem(idx, 3, r.description);
+    fin->SetItem(idx, 4, r.debit);
+    fin->SetItem(idx, 5, r.credit);
+    fin->SetItem(idx, 6, r.balance);
+    fin->SetItem(idx, 7, r.notes);
+  }
+
+  wxPdfDocument doc(wxLANDSCAPE);
+  doc.AddPage();
+
+  wxPdfListCtrlOptions options;
+  options.SetStyle(wxPDF_LISTCTRL_STYLE_SIMPLE);
+  options.SetFitToPage(true);
+
+  doc.AddList(fin, options);
+  doc.SaveAsFile(saveFileDialog.GetPath());
+  fin->Destroy();
 }
 
 void MyFrame::OnExit(wxCommandEvent& WXUNUSED(event))

--- a/samples/listctrl/listctrlsample.cpp
+++ b/samples/listctrl/listctrlsample.cpp
@@ -1,0 +1,154 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        samples/listctrl/listctrlsample.cpp
+// Purpose:     wxListCtrl export demo
+// Author:      Blake Madden
+// Created:     2026-06-10
+// Copyright:   (c) Blake Madden
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#include <wx/wx.h>
+#include <wx/listctrl.h>
+#include <wx/imaglist.h>
+#include <wx/artprov.h>
+
+#include "wx/pdfdoc.h"
+#include "wx/pdflistctrl.h"
+#include "wx/pdfdc.h"
+
+#include "listctrlsample.h"
+
+wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
+  EVT_MENU(ID_EXPORT_DIRECT, MyFrame::OnExportDirect)
+  EVT_MENU(ID_EXPORT_DC, MyFrame::OnExportDC)
+  EVT_MENU(wxID_EXIT, MyFrame::OnExit)
+wxEND_EVENT_TABLE()
+
+MyFrame::MyFrame(const wxString& title)
+  : wxFrame(NULL, wxID_ANY, title, wxDefaultPosition, wxSize(800, 600))
+{
+  wxMenu* menuFile = new wxMenu;
+  menuFile->Append(ID_EXPORT_DIRECT, "&Export to PDF (Direct)\tCtrl-E", "Export using wxPdfDocument::AddList");
+  menuFile->Append(ID_EXPORT_DC, "Export to PDF (via &DC)\tCtrl-D", "Export using wxPdfDC::DrawList");
+  menuFile->AppendSeparator();
+  menuFile->Append(wxID_EXIT);
+
+  wxMenuBar* menuBar = new wxMenuBar;
+  menuBar->Append(menuFile, "&File");
+  SetMenuBar(menuBar);
+
+  m_list = new wxListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT | wxLC_HRULES | wxLC_VRULES);
+  
+  m_imageList = new wxImageList(16, 16);
+  m_imageList->Add(wxArtProvider::GetIcon(wxART_INFORMATION, wxART_MENU, wxSize(16, 16)));
+  m_imageList->Add(wxArtProvider::GetIcon(wxART_WARNING, wxART_MENU, wxSize(16, 16)));
+  m_imageList->Add(wxArtProvider::GetIcon(wxART_ERROR, wxART_MENU, wxSize(16, 16)));
+  m_list->SetImageList(m_imageList, wxIMAGE_LIST_SMALL);
+
+  PopulateList();
+}
+
+void MyFrame::PopulateList()
+{
+  m_list->InsertColumn(0, "ID", wxLIST_FORMAT_LEFT, 50);
+  m_list->InsertColumn(1, "Name", wxLIST_FORMAT_LEFT, 200);
+  m_list->InsertColumn(2, "Status", wxLIST_FORMAT_CENTER, 100);
+  m_list->InsertColumn(3, "Value", wxLIST_FORMAT_RIGHT, 100);
+  m_list->InsertColumn(4, "Notes", wxLIST_FORMAT_LEFT, 250);
+
+  for (int i = 0; i < 200; ++i)
+  {
+    long index = m_list->InsertItem(i, wxString::Format("%d", i + 1));
+    m_list->SetItem(index, 1, wxString::Format("Item Name %d", i + 1));
+    
+    wxString status;
+    int imgIndex = -1;
+    if (i % 3 == 0)
+        { status = "OK"; imgIndex = 0; }
+    else if (i % 3 == 1)
+        { status = "Warning"; imgIndex = 1; }
+    else
+        { status = "Error"; imgIndex = 2; }
+    
+    m_list->SetItem(index, 2, status, imgIndex);
+    
+    // Set cell styling
+    if (status == "OK") {
+        m_list->SetItemBackgroundColour(index, wxColour(200, 255, 200)); // Light green
+    } else if (status == "Warning") {
+        m_list->SetItemTextColour(index, *wxRED); // Red font
+    }
+    
+    m_list->SetItem(index, 3, wxString::Format("%.2f", (double)i * 1.23));
+    m_list->SetItem(index, 4, "This is a note.");
+
+    if (i % 2 == 0 && status != "OK") // Zebra striping
+    {
+      m_list->SetItemBackgroundColour(index, *wxLIGHT_GREY);
+    }
+  }
+}
+
+void MyFrame::OnExportDirect(wxCommandEvent& WXUNUSED(event))
+{
+  wxFileDialog saveFileDialog(this, _("Save PDF file"), "", "list_direct.pdf",
+    "PDF files (*.pdf)|*.pdf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+  if (saveFileDialog.ShowModal() == wxID_CANCEL)
+    return;
+
+  wxPdfDocument doc;
+  doc.AddPage();
+  
+  wxPdfListCtrlOptions options;
+  options.SetHeaderBackgroundColour(wxPdfColour(230, 200, 180));
+  options.SetHeaderTextColour(*wxBLACK);
+  options.SetAlternateRowBackgroundColour(wxPdfColour(240, 240, 240));
+  options.SetBorderColour(wxPdfColour(200, 200, 200));
+  
+  doc.AddList(m_list, options);
+  doc.SaveAsFile(saveFileDialog.GetPath());
+}
+
+void MyFrame::OnExportDC(wxCommandEvent& WXUNUSED(event))
+{
+  wxFileDialog saveFileDialog(this, _("Save PDF file"), "", "list_dc.pdf",
+    "PDF files (*.pdf)|*.pdf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+
+  if (saveFileDialog.ShowModal() == wxID_CANCEL)
+    return;
+
+  wxPrintData printData;
+  printData.SetFilename(saveFileDialog.GetPath());
+  
+  wxPdfDC dc(printData);
+  dc.StartDoc("List Export via DC");
+  dc.StartPage();
+  
+  dc.SetFont(*wxSWISS_FONT);
+  dc.DrawText("Exported List via wxPdfDC", 10, 10);
+  
+  wxPdfListCtrlOptions options;
+  options.SetHeaderBackgroundColour(wxPdfColour(230, 200, 180));
+  options.SetHeaderTextColour(*wxBLACK);
+  options.SetBorderColour(wxPdfColour(200, 200, 200));
+  
+  dc.DrawList(m_list, 10, 30, options);
+  
+  dc.EndPage();
+  dc.EndDoc();
+}
+
+void MyFrame::OnExit(wxCommandEvent& WXUNUSED(event))
+{
+  Close(true);
+}
+
+bool MyApp::OnInit()
+{
+  MyFrame* frame = new MyFrame("wxPdfDocument wxListCtrl Export Sample");
+  frame->Show(true);
+  return true;
+}
+
+IMPLEMENT_APP(MyApp)

--- a/samples/listctrl/listctrlsample.h
+++ b/samples/listctrl/listctrlsample.h
@@ -1,0 +1,46 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        samples/listctrl/listctrlsample.h
+// Purpose:     wxListCtrl export demo
+// Author:      Blake Madden
+// Created:     2026-06-10
+// Copyright:   (c) Blake Madden
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _LISTCTRL_SAMPLE_H_
+#define _LISTCTRL_SAMPLE_H_
+
+#include <wx/wx.h>
+#include <wx/listctrl.h>
+
+class MyFrame : public wxFrame
+{
+public:
+  MyFrame(const wxString& title);
+
+private:
+  void OnExportDirect(wxCommandEvent& event);
+  void OnExportDC(wxCommandEvent& event);
+  void OnExit(wxCommandEvent& event);
+
+  wxListCtrl* m_list;
+  wxImageList* m_imageList;
+
+  void PopulateList();
+
+  wxDECLARE_EVENT_TABLE();
+};
+
+class MyApp : public wxApp
+{
+public:
+  virtual bool OnInit();
+};
+
+enum
+{
+  ID_EXPORT_DIRECT = wxID_HIGHEST + 1,
+  ID_EXPORT_DC
+};
+
+#endif

--- a/samples/listctrl/listctrlsample.h
+++ b/samples/listctrl/listctrlsample.h
@@ -23,6 +23,7 @@ private:
   void OnExportDC(wxCommandEvent& event);
   void OnExportFullWidth(wxCommandEvent& event);
   void OnExportSimple(wxCommandEvent& event);
+  void OnExportFinancial(wxCommandEvent& event);
   void OnExit(wxCommandEvent& event);
 
   wxListCtrl* m_list;
@@ -44,7 +45,8 @@ enum
   ID_EXPORT_DIRECT = wxID_HIGHEST + 1,
   ID_EXPORT_DC,
   ID_EXPORT_FULL_WIDTH,
-  ID_EXPORT_SIMPLE
+  ID_EXPORT_SIMPLE,
+  ID_EXPORT_FINANCIAL
 };
 
 #endif

--- a/samples/listctrl/listctrlsample.h
+++ b/samples/listctrl/listctrlsample.h
@@ -21,6 +21,7 @@ public:
 private:
   void OnExportDirect(wxCommandEvent& event);
   void OnExportDC(wxCommandEvent& event);
+  void OnExportFullWidth(wxCommandEvent& event);
   void OnExit(wxCommandEvent& event);
 
   wxListCtrl* m_list;
@@ -40,7 +41,8 @@ public:
 enum
 {
   ID_EXPORT_DIRECT = wxID_HIGHEST + 1,
-  ID_EXPORT_DC
+  ID_EXPORT_DC,
+  ID_EXPORT_FULL_WIDTH
 };
 
 #endif

--- a/samples/listctrl/listctrlsample.h
+++ b/samples/listctrl/listctrlsample.h
@@ -22,6 +22,7 @@ private:
   void OnExportDirect(wxCommandEvent& event);
   void OnExportDC(wxCommandEvent& event);
   void OnExportFullWidth(wxCommandEvent& event);
+  void OnExportSimple(wxCommandEvent& event);
   void OnExit(wxCommandEvent& event);
 
   wxListCtrl* m_list;
@@ -42,7 +43,8 @@ enum
 {
   ID_EXPORT_DIRECT = wxID_HIGHEST + 1,
   ID_EXPORT_DC,
-  ID_EXPORT_FULL_WIDTH
+  ID_EXPORT_FULL_WIDTH,
+  ID_EXPORT_SIMPLE
 };
 
 #endif

--- a/samples/listctrl/listctrlsample.rc
+++ b/samples/listctrl/listctrlsample.rc
@@ -1,0 +1,1 @@
+#include "wx/msw/wx.rc"

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -1,0 +1,366 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        pdflistctrl.cpp
+// Purpose:     
+// Author:      Ulrich Telle
+// Created:     2026-06-10
+// Copyright:   (c) Ulrich Telle
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+// For compilers that support precompilation, includes "wx/wx.h".
+#include <wx/wxprec.h>
+
+#ifdef __BORLANDC__
+#pragma hdrstop
+#endif
+
+#if wxUSE_LISTCTRL
+
+#include "wx/pdflistctrl.h"
+#include <wx/listctrl.h>
+#include <wx/imaglist.h>
+#include "wx/pdfdocument.h"
+#include "wx/pdfdc.h"
+
+#include <vector>
+#include <numeric>
+#include <algorithm>
+
+wxPdfListCtrlOptions::wxPdfListCtrlOptions()
+{
+  m_drawRowBorders = true;
+  m_drawColumnBorders = true;
+  m_showContinued = true;
+  m_borderColour = wxPdfColour();
+}
+
+// --- Exporter Engine ---
+
+class wxPdfListCtrlExporter
+{
+public:
+  wxPdfListCtrlExporter(wxPdfDocument* doc, wxListCtrl* list, const wxPdfListCtrlOptions& options)
+    : m_doc(doc), m_list(list), m_options(options), m_dc(NULL)
+  {
+  }
+
+  wxPdfListCtrlExporter(wxPdfDC* dc, wxListCtrl* list, const wxPdfListCtrlOptions& options)
+    : m_doc(dc->GetPdfDocument()), m_list(list), m_options(options), m_dc(dc)
+  {
+  }
+
+  void Export(double x, double y)
+  {
+    if (!m_doc || !m_list || m_list->GetColumnCount() == 0)
+        return;
+
+    // Save current state
+    wxPdfColour saveDrawColour = m_doc->GetDrawColour();
+    wxPdfColour saveFillColour = m_doc->GetFillColour();
+    wxPdfColour saveTextColour = m_doc->GetTextColour();
+    double saveLineWidth = m_doc->GetLineWidth();
+    wxPdfFont saveFont;
+    int saveStyle = m_doc->GetFontStyles();
+    double saveSize = m_doc->GetFontSize();
+    { wxLogNull noLog; saveFont = m_doc->GetCurrentFont(); }
+
+    // Calculate column widths
+    size_t colCount = m_list->GetColumnCount();
+    std::vector<double> colWidths(colCount);
+    
+    m_doc->SetFont(m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont());
+    // Cell padding in user units: 4pt converted to the document's unit system
+    const double cellPadding = 4.0 / m_doc->GetScaleFactor();
+    double totalWidth = 0;
+    for (size_t col = 0; col < colCount; ++col)
+    {
+      wxListItem item;
+      item.SetMask(wxLIST_MASK_TEXT | wxLIST_MASK_WIDTH);
+      m_list->GetColumn(col, item);
+
+      double headerWidth = m_doc->GetStringWidth(item.GetText()) + cellPadding;
+      double maxContentWidth = 0;
+
+      // Check first 100 items for width optimization
+      int rowCount = m_list->GetItemCount();
+      int checkRows = std::min(rowCount, 100);
+      wxImageList* imgList = m_list->GetImageList(wxIMAGE_LIST_SMALL);
+      for (int row = 0; row < checkRows; ++row)
+      {
+        double w = m_doc->GetStringWidth(m_list->GetItemText(row, col)) + cellPadding;
+        
+        // Add icon width if present
+        if (imgList)
+        {
+          wxListItem info;
+          info.SetId(row);
+          info.SetColumn(col);
+          info.SetMask(wxLIST_MASK_IMAGE);
+          if (m_list->GetItem(info) && info.GetImage() != -1)
+          {
+            w += 20.0 / m_doc->GetScaleFactor(); // Approx icon width + padding in user units
+          }
+        }
+        
+        if (w > maxContentWidth) maxContentWidth = w;
+      }
+      
+      colWidths[col] = std::max(headerWidth, maxContentWidth);
+      totalWidth += colWidths[col];
+    }
+
+    // Adjust if too wide for the page
+    double pageWidth = m_doc->GetPageWidth() - m_doc->GetLeftMargin() - m_doc->GetRightMargin();
+    int blocksPerPage = 1;
+    if (totalWidth < pageWidth / 2.0)
+    {
+      blocksPerPage = static_cast<int>(pageWidth / totalWidth);
+      if (blocksPerPage > 3) blocksPerPage = 3; // Limit to 3 blocks
+    }
+
+    if (totalWidth > pageWidth)
+    {
+      double scale = pageWidth / totalWidth;
+      for (size_t col = 0; col < colCount; ++col)
+      {
+        colWidths[col] *= scale;
+      }
+      totalWidth = pageWidth;
+    }
+
+    // Drawing — font size is in points; divide by scale factor to get user units
+    double rowHeight = m_doc->GetFontSize() / m_doc->GetScaleFactor() * 1.5;
+    double blockWidth = totalWidth + 5.0 / m_doc->GetScaleFactor(); // Margin between blocks in user units
+    double startX = x;
+    double startY = y;
+    double pageHeight = m_doc->GetPageHeight() - m_doc->GetBreakMargin();
+
+    // Calculate how many rows fit in a block
+    int rowsPerBlock = static_cast<int>((pageHeight - startY) / rowHeight) - 1; // -1 for header
+    if (m_options.GetShowContinued())
+    {
+      rowsPerBlock -= 1; // Reserve space for footer
+    }
+    if (rowsPerBlock < 1) rowsPerBlock = m_list->GetItemCount();
+
+    auto DrawHeader = [&](double headerX, double headerY)
+    {
+      m_doc->SetXY(headerX, headerY);
+      
+      // Determine header font
+      wxFont headerFont = m_options.GetHeaderFont().IsOk() ? m_options.GetHeaderFont() : m_list->GetFont();
+      headerFont.SetWeight(wxFONTWEIGHT_BOLD);
+      m_doc->SetFont(headerFont);
+      
+      if (m_options.GetHeaderBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+      {
+        m_doc->SetFillColour(m_options.GetHeaderBackgroundColour());
+      }
+      if (m_options.GetHeaderTextColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+      {
+        m_doc->SetTextColour(m_options.GetHeaderTextColour());
+      }
+
+      for (size_t col = 0; col < colCount; ++col)
+      {
+        wxListItem item;
+        item.SetMask(wxLIST_MASK_TEXT);
+        m_list->GetColumn(col, item);
+        
+        if (m_options.GetBorderColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+        {
+          m_doc->SetDrawColour(m_options.GetBorderColour());
+        }
+        
+        m_doc->Cell(colWidths[col], rowHeight, item.GetText(), wxPDF_BORDER_FRAME, 0, wxPDF_ALIGN_CENTER,
+                    m_options.GetHeaderBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN ? 1 : 0);
+      }
+      
+      // Reset to body font
+      m_doc->SetFont(m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont());
+    };
+
+    int totalRows = m_list->GetItemCount();
+    int pages = 0;
+    for (int row = 0; row < totalRows; )
+    {
+      // Check if we need a new page
+      if (row > 0 && row % (rowsPerBlock * blocksPerPage) == 0)
+      {
+        // Add "Continued on next page" if another page follows
+        if (m_options.GetShowContinued() && row < totalRows)
+        {
+          wxFont footerFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
+          footerFont.SetStyle(wxFONTSTYLE_ITALIC);
+          m_doc->SetFont(footerFont);
+          m_doc->SetTextColour(saveTextColour);
+          m_doc->SetXY(m_doc->GetPageWidth() - m_doc->GetRightMargin() - 50,
+                       startY + rowHeight * (rowsPerBlock + 1));
+          m_doc->Cell(50, rowHeight, _("Continued on next page"), 0, 0, wxPDF_ALIGN_RIGHT);
+        }
+
+        m_doc->AddPage();
+        startY = m_doc->GetTopMargin(); // Reset startY on new page
+        pages++;
+
+        if (m_options.GetShowContinued() && pages > 0)
+        {
+            wxFont continuedFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
+            continuedFont.SetStyle(wxFONTSTYLE_ITALIC);
+            m_doc->SetFont(continuedFont);
+            m_doc->SetTextColour(saveTextColour);
+            m_doc->Cell(0, rowHeight, _("(continued)"), 0, 1, wxPDF_ALIGN_LEFT);
+            startY += rowHeight;
+        }
+      }
+
+      // Draw blocks for this set of rows
+      for (int block = 0; block < blocksPerPage; ++block)
+      {
+        int rowIdx = row + block * rowsPerBlock;
+        if (rowIdx >= totalRows) break;
+
+        double curX = startX + block * blockWidth;
+        double curY = startY + (row % rowsPerBlock) * rowHeight;
+        
+        // Draw header if this is the start of a block on the page
+        if (row == 0 || (row % rowsPerBlock == 0))
+        {
+          DrawHeader(curX, startY);
+          curY += rowHeight;
+        }
+
+        // Draw rows for this block
+        int rowsInBlock = std::min(rowsPerBlock, totalRows - rowIdx);
+        for (int i = 0; i < rowsInBlock; ++i)
+        {
+          int currentRow = rowIdx + i;
+          
+          m_doc->SetTextColour(saveTextColour); // Ensure text color is reset for each row
+          
+          // ... [drawing code for row]
+          bool useAlt = (currentRow % 2 != 0) && m_options.GetAlternateRowBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN;
+          if (useAlt)
+          {
+            m_doc->SetFillColour(m_options.GetAlternateRowBackgroundColour());
+          }
+
+          m_doc->SetXY(curX, curY);
+          for (size_t col = 0; col < colCount; ++col)
+          {
+            int border = 0;
+            if (m_options.GetDrawRowBorders())
+                border |= wxPDF_BORDER_TOP | wxPDF_BORDER_BOTTOM;
+            if (m_options.GetDrawColumnBorders())
+                border |= wxPDF_BORDER_LEFT | wxPDF_BORDER_RIGHT;
+            
+            wxString text = m_list->GetItemText(currentRow, col);
+            
+            // Set cell colors
+            bool fill = false;
+            wxColour bgColour = m_list->GetItemBackgroundColour(currentRow);
+            if (bgColour.IsOk())
+            {
+              m_doc->SetFillColour(bgColour);
+              fill = true;
+            }
+            else if (useAlt)
+            {
+              m_doc->SetFillColour(m_options.GetAlternateRowBackgroundColour());
+              fill = true;
+            }
+            
+            if (m_options.GetBorderColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+            {
+              m_doc->SetDrawColour(m_options.GetBorderColour());
+            }
+            
+            wxColour textColour = m_list->GetItemTextColour(currentRow);
+            if (textColour.IsOk())
+            {
+              m_doc->SetTextColour(textColour);
+            }
+            else
+            {
+              m_doc->SetTextColour(saveTextColour);
+            }
+            
+            // Draw icon if available
+            wxImageList* imgList = m_list->GetImageList(wxIMAGE_LIST_SMALL);
+            if (imgList)
+            {
+              wxListItem info;
+              info.SetId(currentRow);
+              info.SetColumn(col);
+              info.SetMask(wxLIST_MASK_IMAGE);
+              m_list->GetItem(info);
+              if (info.GetImage() != -1)
+              {
+                wxBitmap bmp = imgList->GetBitmap(info.GetImage());
+                if (bmp.IsOk())
+                {
+                  double imgW, imgH;
+                  if (m_dc)
+                  {
+                    double docScale = 72.0 / (m_dc->GetResolution() * m_doc->GetScaleFactor());
+                    imgW = m_dc->LogicalToDeviceXRel(bmp.GetWidth()) * docScale;
+                    imgH = m_dc->LogicalToDeviceYRel(bmp.GetHeight()) * docScale;
+                  }
+                  else
+                  {
+                    imgW = bmp.GetWidth() * 72.0 / 96.0;
+                    imgH = bmp.GetHeight() * 72.0 / 96.0;
+                  }
+                  double scale = (rowHeight * 0.8) / imgH;
+                  if (scale < 1.0) { imgW *= scale; imgH *= scale; }
+                  
+                  double iconX = m_doc->GetX() + 1;
+                  double iconY = m_doc->GetY() + (rowHeight - imgH) / 2;
+                  m_doc->Image(wxString::Format(wxS("listicon_%d"), info.GetImage()),
+                                                bmp.ConvertToImage(), iconX, iconY, imgW, imgH);
+                  text = wxS("     ") + text;
+                }
+              }
+            }
+
+            m_doc->Cell(colWidths[col], rowHeight, text, border, 0, wxPDF_ALIGN_LEFT, fill ? 1 : 0);
+          }
+          curY += rowHeight;
+        }
+      }
+      row += rowsPerBlock * blocksPerPage;
+    }
+    // Restore state
+    m_doc->SetDrawColour(saveDrawColour);
+    m_doc->SetFillColour(saveFillColour);
+    m_doc->SetTextColour(saveTextColour);
+    m_doc->SetLineWidth(saveLineWidth);
+    if (saveFont.IsValid())
+      m_doc->SetFont(saveFont, saveStyle, saveSize);
+  }
+
+private:
+  wxPdfDocument* m_doc;
+  wxListCtrl*    m_list;
+  const wxPdfListCtrlOptions& m_options;
+  wxPdfDC*       m_dc;
+};
+
+// --- API Implementation ---
+
+void wxPdfDocument::AddList(wxListCtrl* list, const wxPdfListCtrlOptions& options)
+{
+  if (PageNo() == 0)
+    AddPage();
+  wxPdfListCtrlExporter exporter(this, list, options);
+  exporter.Export(GetX(), GetY());
+}
+
+void wxPdfDC::DrawList(wxListCtrl* list, wxCoord x, wxCoord y, const wxPdfListCtrlOptions& options)
+{
+  wxPdfDCImpl* impl = static_cast<wxPdfDCImpl*>(GetImpl());
+  wxPdfListCtrlExporter exporter(this, list, options);
+  exporter.Export(impl->ScaleLogicalToPdfX(x), impl->ScaleLogicalToPdfY(y));
+}
+
+#endif // wxUSE_LISTCTRL

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -250,9 +250,11 @@ public:
           m_doc->SetFont(footerFont);
           m_doc->SetFontSize(scaledBodySize);
           m_doc->SetTextColour(saveTextColour);
-          m_doc->SetXY(m_doc->GetPageWidth() - m_doc->GetRightMargin() - 50,
+          const wxString footerText = _("Continued on next page");
+          const double footerW = m_doc->GetStringWidth(footerText) + 2.0 / m_doc->GetScaleFactor();
+          m_doc->SetXY(m_doc->GetPageWidth() - m_doc->GetRightMargin() - footerW,
                        startY + rowHeight * (rowsPerBlock + 1));
-          m_doc->Cell(50, rowHeight, _("Continued on next page"), 0, 0, wxPDF_ALIGN_RIGHT);
+          m_doc->Cell(footerW, rowHeight, footerText, 0, 0, wxPDF_ALIGN_RIGHT);
         }
 
         if (isSimple)

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -151,7 +151,7 @@ public:
     {
       if (totalWidth < pageWidth / 2.0)
       {
-        blocksPerPage = static_cast<int>(pageWidth / totalWidth);
+        blocksPerPage = static_cast<int>(pageWidth / (totalWidth + 5.0 / m_doc->GetScaleFactor()));
         if (blocksPerPage > 3) blocksPerPage = 3; // Limit to 3 blocks
       }
 

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -135,13 +135,15 @@ public:
     double startY = y;
     double pageHeight = m_doc->GetPageHeight() - m_doc->GetBreakMargin();
 
-    // Calculate how many rows fit in a block
-    int rowsPerBlock = static_cast<int>((pageHeight - startY) / rowHeight) - 1; // -1 for header
-    if (m_options.GetShowContinued())
-    {
-      rowsPerBlock -= 1; // Reserve space for footer
-    }
-    if (rowsPerBlock < 1) rowsPerBlock = m_list->GetItemCount();
+    auto CalcRowsPerBlock = [&](double sy) {
+      int rpb = static_cast<int>((pageHeight - sy) / rowHeight) - 1; // -1 for header
+      if (m_options.GetShowContinued())
+        rpb -= 1; // Reserve space for footer
+      return (rpb < 1) ? m_list->GetItemCount() : rpb;
+    };
+
+    int rowsPerBlock = CalcRowsPerBlock(startY);
+    int nextPageRow = rowsPerBlock * blocksPerPage;
 
     auto DrawHeader = [&](double headerX, double headerY)
     {
@@ -185,7 +187,7 @@ public:
     for (int row = 0; row < totalRows; )
     {
       // Check if we need a new page
-      if (row > 0 && row % (rowsPerBlock * blocksPerPage) == 0)
+      if (row > 0 && row >= nextPageRow)
       {
         // Add "Continued on next page" if another page follows
         if (m_options.GetShowContinued() && row < totalRows)
@@ -212,6 +214,11 @@ public:
             m_doc->Cell(0, rowHeight, _("(continued)"), 0, 1, wxPDF_ALIGN_LEFT);
             startY += rowHeight;
         }
+
+        // Recalculate rows per block for this page's available height,
+        // then advance the page-break threshold by the new stride
+        rowsPerBlock = CalcRowsPerBlock(startY);
+        nextPageRow += rowsPerBlock * blocksPerPage;
       }
 
       // Draw blocks for this set of rows
@@ -299,18 +306,12 @@ public:
                 wxBitmap bmp = imgList->GetBitmap(info.GetImage());
                 if (bmp.IsOk())
                 {
-                  double imgW, imgH;
-                  if (m_dc)
-                  {
-                    double docScale = 72.0 / (m_dc->GetResolution() * m_doc->GetScaleFactor());
-                    imgW = m_dc->LogicalToDeviceXRel(bmp.GetWidth()) * docScale;
-                    imgH = m_dc->LogicalToDeviceYRel(bmp.GetHeight()) * docScale;
-                  }
-                  else
-                  {
-                    imgW = bmp.GetWidth() * 72.0 / 96.0;
-                    imgH = bmp.GetHeight() * 72.0 / 96.0;
-                  }
+                  // bmp.GetWidth/Height() are already in device pixels; convert to
+                  // document user units via DPI and the document's scale factor
+                  double dpi = m_dc ? static_cast<double>(m_dc->GetResolution()) : 96.0;
+                  double docScale = 72.0 / (dpi * m_doc->GetScaleFactor());
+                  double imgW = bmp.GetWidth()  * docScale;
+                  double imgH = bmp.GetHeight() * docScale;
                   double scale = (rowHeight * 0.8) / imgH;
                   if (scale < 1.0) { imgW *= scale; imgH *= scale; }
                   

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -190,14 +190,16 @@ public:
       m_doc->SetDrawColour(saveDrawColour);
     };
 
-    auto CalcRowsPerBlock = [&](double sy) {
+    int totalRows = m_list->GetItemCount();
+
+    auto CalcRowsPerBlock = [&](double sy, int currentRow) {
       int rpb = static_cast<int>((pageHeight - sy) / rowHeight) - 1; // -1 for header
-      if (m_options.GetShowContinued())
-        rpb -= 1; // Reserve space for footer
-      return (rpb < 1) ? m_list->GetItemCount() : rpb;
+      if (m_options.GetShowContinued() && currentRow + rpb * blocksPerPage < totalRows)
+        rpb -= 1; // Reserve space for "Continued" footer only when another page follows
+      return (rpb < 1) ? totalRows : rpb;
     };
 
-    int rowsPerBlock = CalcRowsPerBlock(startY);
+    int rowsPerBlock = CalcRowsPerBlock(startY, 0);
     int nextPageRow = rowsPerBlock * blocksPerPage;
 
     auto DrawHeader = [&](double headerX, double headerY)
@@ -236,7 +238,6 @@ public:
       m_doc->SetFontSize(scaledBodySize);
     };
 
-    int totalRows = m_list->GetItemCount();
     for (int row = 0; row < totalRows; )
     {
       // Check if we need a new page
@@ -275,7 +276,7 @@ public:
 
         // Recalculate rows per block for this page's available height,
         // then advance the page-break threshold by the new stride
-        rowsPerBlock = CalcRowsPerBlock(startY);
+        rowsPerBlock = CalcRowsPerBlock(startY, row);
         nextPageRow += rowsPerBlock * blocksPerPage;
       }
 

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -19,6 +19,7 @@
 #include "wx/pdflistctrl.h"
 #include <wx/listctrl.h>
 #include <wx/imaglist.h>
+#include <wx/log.h>
 #include "wx/pdfdocument.h"
 #include "wx/pdfdc.h"
 

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -33,6 +33,8 @@ wxPdfListCtrlOptions::wxPdfListCtrlOptions()
   m_showContinued = true;
   m_fitToPage = false;
   m_style = wxPDF_LISTCTRL_STYLE_GRID;
+  m_headerBackgroundColour = wxPdfColour(195, 220, 240);
+  m_headerTextColour = wxPdfColour(0, 0, 0);
   m_borderColour = wxPdfColour();
 }
 

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -114,6 +114,30 @@ public:
     // Adjust column widths to fit the available printable width
     double pageWidth = m_doc->GetPageWidth() - m_doc->GetLeftMargin() - m_doc->GetRightMargin();
     int blocksPerPage = 1;
+
+    // When content overflows the page, shrink the font so every cell's text fits within
+    // its measured column width after scaling. String widths scale linearly with font size,
+    // so one pass is exact (padding is fixed, so we account for it separately).
+    double scaledBodySize = m_doc->GetFontSize();
+    if (totalWidth > pageWidth)
+    {
+      const double textOnlyWidth  = totalWidth - static_cast<double>(colCount) * cellPadding;
+      const double textOnlyTarget = pageWidth  - static_cast<double>(colCount) * cellPadding;
+      if (textOnlyWidth > 0 && textOnlyTarget > 0)
+      {
+        const double fontScale = textOnlyTarget / textOnlyWidth;
+        scaledBodySize = std::max(6.0, scaledBodySize * fontScale);
+        const double actualFontScale = scaledBodySize / m_doc->GetFontSize();
+        m_doc->SetFontSize(scaledBodySize);
+        totalWidth = 0;
+        for (size_t col = 0; col < colCount; ++col)
+        {
+          colWidths[col] = std::max(0.0, colWidths[col] - cellPadding) * actualFontScale + cellPadding;
+          totalWidth += colWidths[col];
+        }
+      }
+    }
+
     if (m_options.GetFitToPage())
     {
       // Stretch (or shrink) all columns proportionally to fill the full page width.
@@ -184,7 +208,8 @@ public:
       wxFont headerFont = m_options.GetHeaderFont().IsOk() ? m_options.GetHeaderFont() : m_list->GetFont();
       headerFont.SetWeight(wxFONTWEIGHT_BOLD);
       m_doc->SetFont(headerFont);
-      
+      m_doc->SetFontSize(scaledBodySize);
+
       if (!isSimple)
       {
         if (m_options.GetHeaderBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
@@ -208,6 +233,7 @@ public:
       
       // Reset to body font
       m_doc->SetFont(m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont());
+      m_doc->SetFontSize(scaledBodySize);
     };
 
     int totalRows = m_list->GetItemCount();
@@ -222,6 +248,7 @@ public:
           wxFont footerFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
           footerFont.SetStyle(wxFONTSTYLE_ITALIC);
           m_doc->SetFont(footerFont);
+          m_doc->SetFontSize(scaledBodySize);
           m_doc->SetTextColour(saveTextColour);
           m_doc->SetXY(m_doc->GetPageWidth() - m_doc->GetRightMargin() - 50,
                        startY + rowHeight * (rowsPerBlock + 1));
@@ -238,6 +265,7 @@ public:
             wxFont continuedFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
             continuedFont.SetStyle(wxFONTSTYLE_ITALIC);
             m_doc->SetFont(continuedFont);
+            m_doc->SetFontSize(scaledBodySize);
             m_doc->SetTextColour(saveTextColour);
             m_doc->Cell(0, rowHeight, _("(continued)"), 0, 1, wxPDF_ALIGN_LEFT);
             startY += rowHeight;

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -32,6 +32,7 @@ wxPdfListCtrlOptions::wxPdfListCtrlOptions()
   m_drawColumnBorders = true;
   m_showContinued = true;
   m_fitToPage = false;
+  m_style = wxPDF_LISTCTRL_STYLE_GRID;
   m_borderColour = wxPdfColour();
 }
 
@@ -139,12 +140,31 @@ public:
       }
     }
 
+    // SIMPLE style suppresses multi-column layout (rules span the full table width)
+    if (m_options.GetStyle() == wxPDF_LISTCTRL_STYLE_SIMPLE)
+      blocksPerPage = 1;
+
     // Drawing — font size is in points; divide by scale factor to get user units
     double rowHeight = m_doc->GetFontSize() / m_doc->GetScaleFactor() * 1.5;
     double blockWidth = totalWidth + 5.0 / m_doc->GetScaleFactor(); // Margin between blocks in user units
     double startX = x;
     double startY = y;
     double pageHeight = m_doc->GetPageHeight() - m_doc->GetBreakMargin();
+
+    const bool isSimple = (m_options.GetStyle() == wxPDF_LISTCTRL_STYLE_SIMPLE);
+    // booktabs-style rule weights in user units (toprule/bottomrule thicker than midrule)
+    const double thickRule = 0.5 / m_doc->GetScaleFactor();
+    const double thinRule  = 0.3 / m_doc->GetScaleFactor();
+    double lastDrawnY = startY;
+
+    auto DrawHRule = [&](double ruleX, double ruleY, double ruleLineWidth) {
+      if (m_options.GetBorderColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+        m_doc->SetDrawColour(m_options.GetBorderColour());
+      m_doc->SetLineWidth(ruleLineWidth);
+      m_doc->Line(ruleX, ruleY, ruleX + totalWidth, ruleY);
+      m_doc->SetLineWidth(saveLineWidth);
+      m_doc->SetDrawColour(saveDrawColour);
+    };
 
     auto CalcRowsPerBlock = [&](double sy) {
       int rpb = static_cast<int>((pageHeight - sy) / rowHeight) - 1; // -1 for header
@@ -165,13 +185,12 @@ public:
       headerFont.SetWeight(wxFONTWEIGHT_BOLD);
       m_doc->SetFont(headerFont);
       
-      if (m_options.GetHeaderBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+      if (!isSimple)
       {
-        m_doc->SetFillColour(m_options.GetHeaderBackgroundColour());
-      }
-      if (m_options.GetHeaderTextColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
-      {
-        m_doc->SetTextColour(m_options.GetHeaderTextColour());
+        if (m_options.GetHeaderBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+          m_doc->SetFillColour(m_options.GetHeaderBackgroundColour());
+        if (m_options.GetHeaderTextColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+          m_doc->SetTextColour(m_options.GetHeaderTextColour());
       }
 
       for (size_t col = 0; col < colCount; ++col)
@@ -179,14 +198,12 @@ public:
         wxListItem item;
         item.SetMask(wxLIST_MASK_TEXT);
         m_list->GetColumn(col, item);
-        
-        if (m_options.GetBorderColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
-        {
+
+        if (!isSimple && m_options.GetBorderColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
           m_doc->SetDrawColour(m_options.GetBorderColour());
-        }
-        
-        m_doc->Cell(colWidths[col], rowHeight, item.GetText(), wxPDF_BORDER_FRAME, 0, wxPDF_ALIGN_CENTER,
-                    m_options.GetHeaderBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN ? 1 : 0);
+
+        int hdrFill = (!isSimple && m_options.GetHeaderBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN) ? 1 : 0;
+        m_doc->Cell(colWidths[col], rowHeight, item.GetText(), isSimple ? 0 : wxPDF_BORDER_FRAME, 0, wxPDF_ALIGN_CENTER, hdrFill);
       }
       
       // Reset to body font
@@ -212,6 +229,8 @@ public:
           m_doc->Cell(50, rowHeight, _("Continued on next page"), 0, 0, wxPDF_ALIGN_RIGHT);
         }
 
+        if (isSimple)
+          DrawHRule(startX, lastDrawnY, thickRule);
         m_doc->AddPage();
         startY = m_doc->GetTopMargin(); // Reset startY on new page
         pages++;
@@ -244,8 +263,12 @@ public:
         // Draw header if this is the start of a block on the page
         if (row == 0 || (row % rowsPerBlock == 0))
         {
+          if (isSimple)
+            DrawHRule(curX, startY, thickRule);
           DrawHeader(curX, startY);
           curY += rowHeight;
+          if (isSimple)
+            DrawHRule(curX, curY, thinRule);
         }
 
         // Draw rows for this block
@@ -256,8 +279,7 @@ public:
           
           m_doc->SetTextColour(saveTextColour); // Ensure text color is reset for each row
           
-          // ... [drawing code for row]
-          bool useAlt = (currentRow % 2 != 0) && m_options.GetAlternateRowBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN;
+          bool useAlt = !isSimple && (currentRow % 2 != 0) && m_options.GetAlternateRowBackgroundColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN;
           if (useAlt)
           {
             m_doc->SetFillColour(m_options.GetAlternateRowBackgroundColour());
@@ -267,30 +289,34 @@ public:
           for (size_t col = 0; col < colCount; ++col)
           {
             int border = 0;
-            if (m_options.GetDrawRowBorders())
+            if (!isSimple)
+            {
+              if (m_options.GetDrawRowBorders())
                 border |= wxPDF_BORDER_TOP | wxPDF_BORDER_BOTTOM;
-            if (m_options.GetDrawColumnBorders())
+              if (m_options.GetDrawColumnBorders())
                 border |= wxPDF_BORDER_LEFT | wxPDF_BORDER_RIGHT;
-            
+            }
+
             wxString text = m_list->GetItemText(currentRow, col);
-            
+
             // Set cell colors
             bool fill = false;
-            wxColour bgColour = m_list->GetItemBackgroundColour(currentRow);
-            if (bgColour.IsOk())
+            if (!isSimple)
             {
-              m_doc->SetFillColour(bgColour);
-              fill = true;
-            }
-            else if (useAlt)
-            {
-              m_doc->SetFillColour(m_options.GetAlternateRowBackgroundColour());
-              fill = true;
-            }
-            
-            if (m_options.GetBorderColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
-            {
-              m_doc->SetDrawColour(m_options.GetBorderColour());
+              wxColour bgColour = m_list->GetItemBackgroundColour(currentRow);
+              if (bgColour.IsOk())
+              {
+                m_doc->SetFillColour(bgColour);
+                fill = true;
+              }
+              else if (useAlt)
+              {
+                m_doc->SetFillColour(m_options.GetAlternateRowBackgroundColour());
+                fill = true;
+              }
+
+              if (m_options.GetBorderColour().GetColourType() != wxPDF_COLOURTYPE_UNKNOWN)
+                m_doc->SetDrawColour(m_options.GetBorderColour());
             }
             
             wxColour textColour = m_list->GetItemTextColour(currentRow);
@@ -338,10 +364,13 @@ public:
             m_doc->Cell(colWidths[col], rowHeight, text, border, 0, wxPDF_ALIGN_LEFT, fill ? 1 : 0);
           }
           curY += rowHeight;
+          lastDrawnY = curY;
         }
       }
       row += rowsPerBlock * blocksPerPage;
     }
+    if (isSimple)
+      DrawHRule(startX, lastDrawnY, thickRule);
     // Restore state
     m_doc->SetDrawColour(saveDrawColour);
     m_doc->SetFillColour(saveFillColour);

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -31,6 +31,7 @@ wxPdfListCtrlOptions::wxPdfListCtrlOptions()
   m_drawRowBorders = true;
   m_drawColumnBorders = true;
   m_showContinued = true;
+  m_fitToPage = false;
   m_borderColour = wxPdfColour();
 }
 
@@ -109,23 +110,33 @@ public:
       totalWidth += colWidths[col];
     }
 
-    // Adjust if too wide for the page
+    // Adjust column widths to fit the available printable width
     double pageWidth = m_doc->GetPageWidth() - m_doc->GetLeftMargin() - m_doc->GetRightMargin();
     int blocksPerPage = 1;
-    if (totalWidth < pageWidth / 2.0)
+    if (m_options.GetFitToPage())
     {
-      blocksPerPage = static_cast<int>(pageWidth / totalWidth);
-      if (blocksPerPage > 3) blocksPerPage = 3; // Limit to 3 blocks
-    }
-
-    if (totalWidth > pageWidth)
-    {
+      // Stretch (or shrink) all columns proportionally to fill the full page width.
+      // Multi-column layout is incompatible with full-width mode.
       double scale = pageWidth / totalWidth;
       for (size_t col = 0; col < colCount; ++col)
-      {
         colWidths[col] *= scale;
-      }
       totalWidth = pageWidth;
+    }
+    else
+    {
+      if (totalWidth < pageWidth / 2.0)
+      {
+        blocksPerPage = static_cast<int>(pageWidth / totalWidth);
+        if (blocksPerPage > 3) blocksPerPage = 3; // Limit to 3 blocks
+      }
+
+      if (totalWidth > pageWidth)
+      {
+        double scale = pageWidth / totalWidth;
+        for (size_t col = 0; col < colCount; ++col)
+          colWidths[col] *= scale;
+        totalWidth = pageWidth;
+      }
     }
 
     // Drawing — font size is in points; divide by scale factor to get user units

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -73,7 +73,10 @@ public:
     size_t colCount = m_list->GetColumnCount();
     std::vector<double> colWidths(colCount);
     
-    m_doc->SetFont(m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont());
+    if (m_options.GetBodyPdfFont().IsValid())
+        m_doc->SetFont(m_options.GetBodyPdfFont(), wxPDF_FONTSTYLE_REGULAR, 0);
+    else
+        m_doc->SetFont(m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont());
     // Cell padding in user units: 4pt converted to the document's unit system
     const double cellPadding = 4.0 / m_doc->GetScaleFactor();
     double totalWidth = 0;
@@ -210,10 +213,14 @@ public:
       m_doc->SetXY(headerX, headerY);
       
       // Determine header font
-      wxFont headerFont = m_options.GetHeaderFont().IsOk() ? m_options.GetHeaderFont() : m_list->GetFont();
-      headerFont.SetWeight(wxFONTWEIGHT_BOLD);
-      m_doc->SetFont(headerFont);
-      m_doc->SetFontSize(scaledBodySize);
+      if (m_options.GetHeaderPdfFont().IsValid())
+          m_doc->SetFont(m_options.GetHeaderPdfFont(), wxPDF_FONTSTYLE_BOLD, scaledBodySize);
+      else {
+          wxFont headerFont = m_options.GetHeaderFont().IsOk() ? m_options.GetHeaderFont() : m_list->GetFont();
+          headerFont.SetWeight(wxFONTWEIGHT_BOLD);
+          m_doc->SetFont(headerFont);
+          m_doc->SetFontSize(scaledBodySize);
+      }
 
       if (!isSimple)
       {
@@ -237,8 +244,12 @@ public:
       }
       
       // Reset to body font
-      m_doc->SetFont(m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont());
-      m_doc->SetFontSize(scaledBodySize);
+      if (m_options.GetBodyPdfFont().IsValid())
+          m_doc->SetFont(m_options.GetBodyPdfFont(), wxPDF_FONTSTYLE_REGULAR, scaledBodySize);
+      else {
+          m_doc->SetFont(m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont());
+          m_doc->SetFontSize(scaledBodySize);
+      }
     };
 
     for (int row = 0; row < totalRows; )
@@ -249,10 +260,14 @@ public:
         // Add "Continued on next page" if another page follows
         if (m_options.GetShowContinued())
         {
-          wxFont footerFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
-          footerFont.SetStyle(wxFONTSTYLE_ITALIC);
-          m_doc->SetFont(footerFont);
-          m_doc->SetFontSize(scaledBodySize);
+          if (m_options.GetBodyPdfFont().IsValid())
+              m_doc->SetFont(m_options.GetBodyPdfFont(), wxPDF_FONTSTYLE_ITALIC, scaledBodySize);
+          else {
+              wxFont footerFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
+              footerFont.SetStyle(wxFONTSTYLE_ITALIC);
+              m_doc->SetFont(footerFont);
+              m_doc->SetFontSize(scaledBodySize);
+          }
           m_doc->SetTextColour(saveTextColour);
           const wxString footerText = _("Continued on next page");
           const double footerW = m_doc->GetStringWidth(footerText) + 2.0 / m_doc->GetScaleFactor();
@@ -268,10 +283,14 @@ public:
 
         if (m_options.GetShowContinued())
         {
-            wxFont continuedFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
-            continuedFont.SetStyle(wxFONTSTYLE_ITALIC);
-            m_doc->SetFont(continuedFont);
-            m_doc->SetFontSize(scaledBodySize);
+            if (m_options.GetBodyPdfFont().IsValid())
+                m_doc->SetFont(m_options.GetBodyPdfFont(), wxPDF_FONTSTYLE_ITALIC, scaledBodySize);
+            else {
+                wxFont continuedFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
+                continuedFont.SetStyle(wxFONTSTYLE_ITALIC);
+                m_doc->SetFont(continuedFont);
+                m_doc->SetFontSize(scaledBodySize);
+            }
             m_doc->SetTextColour(saveTextColour);
             m_doc->Cell(0, rowHeight, _("(continued)"), 0, 1, wxPDF_ALIGN_LEFT);
             startY += rowHeight;

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -211,7 +211,6 @@ public:
     };
 
     int totalRows = m_list->GetItemCount();
-    int pages = 0;
     for (int row = 0; row < totalRows; )
     {
       // Check if we need a new page
@@ -232,10 +231,9 @@ public:
         if (isSimple)
           DrawHRule(startX, lastDrawnY, thickRule);
         m_doc->AddPage();
-        startY = m_doc->GetTopMargin(); // Reset startY on new page
-        pages++;
+        startY = m_doc->GetTopMargin();
 
-        if (m_options.GetShowContinued() && pages > 0)
+        if (m_options.GetShowContinued())
         {
             wxFont continuedFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
             continuedFont.SetStyle(wxFONTSTYLE_ITALIC);
@@ -258,18 +256,14 @@ public:
         if (rowIdx >= totalRows) break;
 
         double curX = startX + block * blockWidth;
-        double curY = startY + (row % rowsPerBlock) * rowHeight;
-        
-        // Draw header if this is the start of a block on the page
-        if (row == 0 || (row % rowsPerBlock == 0))
-        {
-          if (isSimple)
-            DrawHRule(curX, startY, thickRule);
-          DrawHeader(curX, startY);
-          curY += rowHeight;
-          if (isSimple)
-            DrawHRule(curX, curY, thinRule);
-        }
+        double curY = startY;
+
+        if (isSimple)
+          DrawHRule(curX, startY, thickRule);
+        DrawHeader(curX, startY);
+        curY += rowHeight;
+        if (isSimple)
+          DrawHRule(curX, curY, thinRule);
 
         // Draw rows for this block
         int rowsInBlock = std::min(rowsPerBlock, totalRows - rowIdx);

--- a/src/pdflistctrl.cpp
+++ b/src/pdflistctrl.cpp
@@ -243,7 +243,7 @@ public:
       if (row > 0 && row >= nextPageRow)
       {
         // Add "Continued on next page" if another page follows
-        if (m_options.GetShowContinued() && row < totalRows)
+        if (m_options.GetShowContinued())
         {
           wxFont footerFont = m_options.GetBodyFont().IsOk() ? m_options.GetBodyFont() : m_list->GetFont();
           footerFont.SetStyle(wxFONTSTYLE_ITALIC);


### PR DESCRIPTION
These classes can now accept a `wxListCtrl` (with various options) and they will print it within the document (spanning across multiple pages if necessary).

I tried to emulate some of LaTeX table features so that we have lots of customization available.

Sample project is included, but only the CMake project builds it currently; you will need to run the premake script to add it to the other build scripts.

Some examples from the sample project:

<img width="906" height="246" alt="image" src="https://github.com/user-attachments/assets/51b2a494-a04c-43cb-84ea-79fbab28305c" />

<img width="944" height="156" alt="image" src="https://github.com/user-attachments/assets/e450adb2-f06c-4248-8152-57103349d9d4" />

<img width="1328" height="100" alt="image" src="https://github.com/user-attachments/assets/8ae8073b-59ad-4a72-976f-5df7ce91760f" />

<img width="942" height="243" alt="image" src="https://github.com/user-attachments/assets/9c390a42-69bc-48e4-8914-f3595ecd1d8e" />

